### PR TITLE
Update cyclers for PyProBE parity

### DIFF
--- a/src/bdf/__init__.py
+++ b/src/bdf/__init__.py
@@ -293,6 +293,7 @@ def read(
     validate: bool = True,
     include_optional: bool = True,
     registry_path: str | Path | None = None,
+    timezone: str | None = None,
 ) -> pd.DataFrame:
     """
     Universal reader -> DataFrame.
@@ -300,6 +301,8 @@ def read(
       - plugin: force a specific cycler plugin id (optional)
       - normalize: if True, normalize to BDF columns; if False, parse only
       - validate: validate BDF artifacts (or normalized output)
+      - timezone: IANA timezone string for naive timestamps (e.g. "America/New_York");
+                  defaults to plugin's own assume_naive_tz (usually UTC)
     """
     local_path, plugin_hint = _resolve_source(source, registry_path=registry_path)
     if _looks_like_bdf_artifact(local_path):
@@ -322,6 +325,8 @@ def read(
         parse_errors: list[tuple[str, str]] = []
         for plg in _candidate_plugins(local_path, plugin=plugin, plugin_hint=plugin_hint):
             try:
+                if timezone is not None:
+                    plg.assume_naive_tz = timezone
                 return plg.parse(local_path)
             except Exception as exc:
                 if plugin is not None:
@@ -333,6 +338,8 @@ def read(
     normalize_errors: list[tuple[str, str]] = []
     for plg in _candidate_plugins(local_path, plugin=plugin, plugin_hint=plugin_hint):
         try:
+            if timezone is not None:
+                plg.assume_naive_tz = timezone
             df_raw = plg.parse(local_path)
             df_raw = plg.augment(df_raw)
         except Exception as exc:
@@ -358,6 +365,8 @@ def read(
                     , stacklevel=2
                 )
                 plg = alt
+                if timezone is not None:
+                    plg.assume_naive_tz = timezone
                 df_raw = plg.parse(local_path)
                 df_raw = plg.augment(df_raw)
                 df = normalize_columns(df_raw, plugin=plg, strict=True, include_optional=include_optional)
@@ -386,9 +395,9 @@ def read(
 
 
 
-def parse(source: str | Path, plugin: str | None = None, registry_path: str | Path | None = None) -> pd.DataFrame:
+def parse(source: str | Path, plugin: str | None = None, registry_path: str | Path | None = None, timezone: str | None = None) -> pd.DataFrame:
     """Parse vendor file only (no normalization/validation)."""
-    return read(source, plugin=plugin, normalize=False, validate=False, registry_path=registry_path)
+    return read(source, plugin=plugin, normalize=False, validate=False, registry_path=registry_path, timezone=timezone)
 
 
 def normalize(df: pd.DataFrame, plugin: str | None = None) -> pd.DataFrame:

--- a/src/bdf/data_sources/arbin_csv.py
+++ b/src/bdf/data_sources/arbin_csv.py
@@ -1,0 +1,59 @@
+# src/bdf/data_sources/arbin_csv.py
+from __future__ import annotations
+
+from .base_delimited import DelimitedTextPlugin
+
+
+class ArbinCSV(DelimitedTextPlugin):
+    """Arbin CSV export. Single header row, UTF-8 BOM, comma-separated.
+    Columns carry explicit units in parentheses; time in seconds, capacity in Ah.
+    'Date Time' column (MM/DD/YYYY HH:MM:SS.f) is used for Unix Time / s.
+    """
+    id = "arbin-csv"
+    exts = (".csv",)
+    default_encoding = "utf-8-sig"
+
+    header_token_patterns = (
+        r"\btest time \(s\)\b",
+        r"\bvoltage \(v\)\b",
+        r"\bcurrent \(a\)\b",
+        r"\bcycle index\b",
+        r"\bstep index\b",
+    )
+
+    # 'Date Time' matches the base CyclerPlugin timestamp_candidate_patterns
+    # (r"^date[_\s/:-]*time$") so Unix Time / s is derived automatically via augment().
+    # Format MM/DD/YYYY HH:MM:SS.f is handled by pd.to_datetime auto-detection.
+
+    column_synonyms = {
+        "Test Time / s":          ["test time (s)"],
+        "Step Time / s":          ["step time (s)"],
+        "Voltage / V":            ["voltage (v)"],
+        "Current / A":            ["current (a)"],
+        "Cycle Count / 1":        ["cycle index"],
+        "Step Index / 1":         ["step index"],
+        "Charging Capacity / Ah": ["charge capacity (ah)"], # cumulative over experiment
+        "Discharging Capacity / Ah": ["discharge capacity (ah)"], # cumulative over experiment
+        "Charging Energy / Wh":   ["charge energy (wh)"], # cumulative over experiment
+        "Discharging Energy / Wh": ["discharge energy (wh)"], # cumulative over experiment
+        "Cumulative Capacity / Ah": ["capacity (ah)"], # cumulative over a step
+        "Power / W":              ["power (w)"],
+        "Internal Resistance / ohm": ["internal resistance (ohm)"],
+        "Surface Temperature T1 / degC": ["aux_temperature_1 (c)"],
+    }
+
+    unit_column_patterns = {
+        "Test Time / s":          [(r"^test time \(s\)$", "s")],
+        "Step Time / s":          [(r"^step time \(s\)$", "s")],
+        "Voltage / V":            [(r"^voltage \(v\)$", "V")],
+        "Current / A":            [(r"^current \(a\)$", "A")],
+        "Charging Capacity / Ah": [(r"^charge capacity \(ah\)$", "Ah")],
+        "Discharging Capacity / Ah": [(r"^discharge capacity \(ah\)$", "Ah")],
+        "Charging Energy / Wh":   [(r"^charge energy \(wh\)$", "Wh")],
+        "Discharging Energy / Wh": [(r"^discharge energy \(wh\)$", "Wh")],
+        "Power / W":              [(r"^power \(w\)$", "W")],
+        "Internal Resistance / ohm": [
+            (r"^internal resistance \(ohm\)$", "ohm"),
+        ],
+        "Surface Temperature T1 / degC": [(r"^aux_temperature_1 \(c\)$", "degC")],
+    }

--- a/src/bdf/data_sources/base.py
+++ b/src/bdf/data_sources/base.py
@@ -62,6 +62,8 @@ class CyclerPlugin(metaclass=_AutoRegister):
     )
     # If naive timestamps found, treat as this tz and convert to UTC; set None to treat as UTC already
     assume_naive_tz: str | None = "UTC"
+    # strftime format for timestamp candidate columns; None = let pandas infer (may warn)
+    timestamp_format: str | None = None
 
     # ----- required API -----
     def sniff(self, path: Path, head: bytes) -> SniffResult: ...
@@ -121,7 +123,7 @@ class CyclerPlugin(metaclass=_AutoRegister):
             return df
 
         try:
-            unix = parse_unix_time(df[cand], tz=self.assume_naive_tz, min_success=0.5)
+            unix = parse_unix_time(df[cand], fmt=self.timestamp_format, tz=self.assume_naive_tz, min_success=0.5)
         except Exception:
             return df
 

--- a/src/bdf/data_sources/base_delimited.py
+++ b/src/bdf/data_sources/base_delimited.py
@@ -4,6 +4,7 @@ import csv
 import os
 import re
 from collections.abc import Iterable, Sequence
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
@@ -40,6 +41,10 @@ class DelimitedTextPlugin(CyclerPlugin):
     # --- INI-style preamble / sectioned files (e.g., Novonix with [Data]) ---
     data_section_marker: Optional[str] = None        # regex; if present, start from the line after this marker
     data_header_offset: int = 1                      # number of lines after marker where the header row appears
+
+    # --- header start-time extraction ---
+    start_time_line_regex: Optional[str] = None      # regex with one capture group for the datetime value
+    start_time_format: Optional[str] = None          # strftime format to parse the captured value
 
     # -------------------------------------------------------------------------
     # Public API
@@ -94,6 +99,7 @@ class DelimitedTextPlugin(CyclerPlugin):
             df = self._drop_units_row(df)
 
         self._unit_hints = self._detect_units_from_headers(df.columns)
+        self._start_time_epoch = self._extract_start_time(path, enc)
 
         if self._debug_on():
             print(f"[bdf][DelimitedTextPlugin] columns={list(df.columns)}")
@@ -114,6 +120,22 @@ class DelimitedTextPlugin(CyclerPlugin):
             except Exception:
                 pass
         return b.decode("latin-1", "ignore")
+
+    def _extract_start_time(self, path: Path, enc: str) -> float | None:
+        """Scan header lines for a start timestamp and return it as a Unix epoch float."""
+        if not self.start_time_line_regex or not self.start_time_format:
+            return None
+        pat = re.compile(self.start_time_line_regex, re.IGNORECASE)
+        for line in self._scan_prefix(path, enc):
+            m = pat.search(line)
+            if m:
+                try:
+                    ts = pd.Timestamp(datetime.strptime(m.group(1).strip(), self.start_time_format))
+                    tz = getattr(self, "assume_naive_tz", "UTC") or "UTC"
+                    return ts.tz_localize(tz).tz_convert("UTC").timestamp()
+                except Exception:
+                    return None
+        return None
 
     def _scan_prefix(self, path: Path, enc: str) -> list[str]:
         out: list[str] = []
@@ -471,5 +493,13 @@ class DelimitedTextPlugin(CyclerPlugin):
             u = (hints.get("Voltage / V") or "").lower()
             if u == "mv":
                 out["Voltage / V"] = pd.to_numeric(out["Voltage / V"], errors="coerce") / 1000.0
+
+        start = getattr(self, "_start_time_epoch", None)
+        if (
+            start is not None
+            and "Test Time / s" in out.columns
+            and "Unix Time / s" not in out.columns
+        ):
+            out["Unix Time / s"] = start + pd.to_numeric(out["Test Time / s"], errors="coerce")
 
         return out

--- a/src/bdf/data_sources/base_delimited.py
+++ b/src/bdf/data_sources/base_delimited.py
@@ -255,18 +255,39 @@ class DelimitedTextPlugin(CyclerPlugin):
         return header_idx, sep
 
     def _read_csv(self, path: Path, sep: str, header_idx: int, enc: str) -> pd.DataFrame:
-        df = pd.read_csv(
-            path,
-            sep=sep,
-            skiprows=header_idx,
-            header=0,
-            encoding=enc,
-            engine="python",
-            dtype_backend="pyarrow",
-            decimal=getattr(self, "decimal", ".") or ".",
-        )
-        df.columns = [str(c).strip().lstrip("\ufeff") for c in df.columns]
-        return df
+        # Prefer the C engine for simple delimiters because it is more tolerant
+        # of malformed quoted text in skipped preambles (e.g., Novonix [Protocol]
+        # JSON). Fall back to the Python engine if needed. Regex separators
+        # require the Python engine.
+        is_regex_sep = "\\s" in sep
+        engines = ("python",) if is_regex_sep else ("c", "python")
+        last_exc: Exception | None = None
+
+        for engine in engines:
+            try:
+                df = pd.read_csv(
+                    path,
+                    sep=sep,
+                    skiprows=header_idx,
+                    header=0,
+                    encoding=enc,
+                    engine=engine,
+                    dtype_backend="pyarrow",
+                    decimal=getattr(self, "decimal", ".") or ".",
+                )
+                df.columns = [str(c).strip().lstrip("\ufeff") for c in df.columns]
+                return df
+            except Exception as exc:
+                last_exc = exc
+                if self._debug_on():
+                    print(
+                        "[bdf][DelimitedTextPlugin] read_csv failed "
+                        f"engine={engine!r} sep={sep!r}: {type(exc).__name__}: {exc}"
+                    )
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("CSV read failed with no captured exception.")
 
     def _split_header_fields(self, header_line: str, sep: str) -> list[str]:
         try:

--- a/src/bdf/data_sources/base_delimited.py
+++ b/src/bdf/data_sources/base_delimited.py
@@ -479,9 +479,6 @@ class DelimitedTextPlugin(CyclerPlugin):
                 out[time_col] = pd.to_numeric(out[time_col], errors="coerce") * 3600.0
             elif u == "min":
                 out[time_col] = pd.to_numeric(out[time_col], errors="coerce") * 60.0
-            elif u == "hms":
-                out[time_col] = pd.to_timedelta(out[time_col], errors="coerce").dt.total_seconds()
-
         if "Voltage / V" in out.columns:
             u = (hints.get("Voltage / V") or "").lower()
             if u == "mv":

--- a/src/bdf/data_sources/base_delimited.py
+++ b/src/bdf/data_sources/base_delimited.py
@@ -405,16 +405,9 @@ class DelimitedTextPlugin(CyclerPlugin):
         return out
 
     def _looks_ok(self, df: pd.DataFrame) -> bool:
-        cols_lower = [str(c).lower().strip() for c in df.columns]
-        if any(k in cols_lower for k in ("time/s", "ewe/v", "ecell/v", "i/ma", "current / a")):
-            return True
-        for c in cols_lower:
-            if re.search(r"\btime\[[^\]]+\]", c):
-                return True
-            if re.search(r"\bu\[[^\]]+\]", c):
-                return True
-            if re.search(r"\bi\[[^\]]+\]", c):
-                return True
+        if self.header_token_patterns:
+            cols_joined = " ".join(str(c).lower().strip() for c in df.columns)
+            return any(re.search(p, cols_joined, re.I) for p in self.header_token_patterns)
         return False
 
     def _detect_units_from_headers(self, cols: Iterable[str]) -> dict[str, str]:

--- a/src/bdf/data_sources/base_delimited.py
+++ b/src/bdf/data_sources/base_delimited.py
@@ -456,12 +456,16 @@ class DelimitedTextPlugin(CyclerPlugin):
             elif u == "ua":
                 out["Current / A"] = pd.to_numeric(out["Current / A"], errors="coerce") / 1_000_000.0
 
-        if "Test Time / s" in out.columns:
-            u = (hints.get("Test Time / s") or "").lower()
+        for time_col in ("Test Time / s", "Step Time / s"):
+            if time_col not in out.columns:
+                continue
+            u = (hints.get(time_col) or "").lower()
             if u == "h":
-                out["Test Time / s"] = pd.to_numeric(out["Test Time / s"], errors="coerce") * 3600.0
+                out[time_col] = pd.to_numeric(out[time_col], errors="coerce") * 3600.0
             elif u == "min":
-                out["Test Time / s"] = pd.to_numeric(out["Test Time / s"], errors="coerce") * 60.0
+                out[time_col] = pd.to_numeric(out[time_col], errors="coerce") * 60.0
+            elif u == "hms":
+                out[time_col] = pd.to_timedelta(out[time_col], errors="coerce").dt.total_seconds()
 
         if "Voltage / V" in out.columns:
             u = (hints.get("Voltage / V") or "").lower()

--- a/src/bdf/data_sources/basytec_txt.py
+++ b/src/bdf/data_sources/basytec_txt.py
@@ -26,10 +26,17 @@ class BasytecTxt(DelimitedTextPlugin):
         "Current / A":   ["i[a]", "current[a]", "i", "current"],
         # Optional (kept if present)
         "Ambient Temperature / degC": ["t1[°c]", "t1[c]", "t1[degc]", "temp[°c]", "temperature[°c]"],
+        "Net Capacity / Ah": ["ah[ah]"],
+        "Step Index / 1": ["line"],
     }
+    
+
+    # Extract start time from the "~Start of Test: DD.MM.YYYY HH:MM:SS" header line
+    start_time_line_regex = r"~Start of Test:\s*(.+)"
+    start_time_format = "%d.%m.%Y %H:%M:%S"
 
     # Unit hints so the base .fixup() converts to canonical units:
-    #   Current -> A, Time -> s, Voltage -> V
+    #   Current -> A, Time -> s, Voltage -> V, Capacity -> Ah
     unit_column_patterns = {
         "Test Time / s": [
             (r"^time\[s\]$", "s"),
@@ -45,5 +52,8 @@ class BasytecTxt(DelimitedTextPlugin):
             (r"^i\[a\]$",  "A"),
             (r"^i\[ma\]$", "mA"),
             (r"^i\[ua\]$", "uA"),
+        ],
+        "Net Capacity / Ah": [
+            (r"^ah\[ah\]$", "Ah"),
         ],
     }

--- a/src/bdf/data_sources/biologic_mpt.py
+++ b/src/bdf/data_sources/biologic_mpt.py
@@ -27,6 +27,7 @@ class BioLogicMPT(DelimitedTextPlugin):
         ],
         # Recommended
         "Cycle Count / 1": ["cycle number", "z cycle"],
+        "Step Index / 1": ["ns"],
         "Ambient Temperature / degC": [
             "temperature/c",
             "temperature/degc",
@@ -74,6 +75,9 @@ class BioLogicMPT(DelimitedTextPlugin):
         "Cycle Count / 1": [
             (r"^cycle number$", "1"),
             (r"^z cycle$", "1"),
+        ],
+        "Step Index / 1": [
+            (r"^ns$", "1"),
         ],
         "Ambient Temperature / degC": [
             (r"^temperature/c$", "degC"),

--- a/src/bdf/data_sources/biologic_mpt.py
+++ b/src/bdf/data_sources/biologic_mpt.py
@@ -15,6 +15,10 @@ class BioLogicMPT(DelimitedTextPlugin):
     header_lines_field_regex = r"Nb\s+header\s+lines\s*:\s*(\d+)"
     header_token_patterns = (r"\btime/s\b", r"\bewe/v\b", r"\becell/v\b", r"\bi/ma\b", r"current\s*/\s*a")
 
+    # Extract start time from "Acquisition started on : MM/DD/YYYY HH:MM:SS.f" header line
+    start_time_line_regex = r"Acquisition started on\s*:\s*(.+)"
+    start_time_format = "%m/%d/%Y %H:%M:%S.%f"
+
     column_synonyms = {
         # Required
         "Test Time / s": ["time/s", "time / s", "t (s)", "time [s]", "relative time(s)"],

--- a/src/bdf/data_sources/excel_xlsx.py
+++ b/src/bdf/data_sources/excel_xlsx.py
@@ -20,6 +20,7 @@ class ExcelXlsx(CyclerPlugin):
       3) bdf.excel.json
       4) excel.json
       5) contribution.json / collection.json with an "excel" object (search parents)
+      6) plugin._excel_config_override (class or instance variable, lowest priority)
 
     Config keys (all optional):
       - sheet / sheet_name / worksheet: sheet name or 0-based index
@@ -36,6 +37,7 @@ class ExcelXlsx(CyclerPlugin):
 
     id = "excel-xlsx"
     exts = (".xlsx", ".xlsm", ".xls")
+    _excel_config_override: dict[str, Any] | None = None
 
     def sniff(self, path: Path, head: bytes) -> SniffResult:
         score, reasons = 0.0, []
@@ -52,7 +54,7 @@ class ExcelXlsx(CyclerPlugin):
         return SniffResult(self.id, min(score, 1.0), "+".join(reasons), {})
 
     def parse(self, path: Path) -> pd.DataFrame:
-        cfg = _load_excel_config(path)
+        cfg = _load_excel_config(path, plugin=self)
         sheet = _resolve_sheet(cfg)
         header = _resolve_header(cfg)
         usecols = cfg.get("usecols")
@@ -119,11 +121,13 @@ def _load_json(path: Path) -> dict:
     return raw
 
 
-def _load_excel_config(path: Path) -> dict[str, Any]:
+def _load_excel_config(path: Path, plugin=None) -> dict[str, Any]:
+    # 1) Check environment variable (highest priority for explicit override)
     env = os.environ.get("BDF_EXCEL_CONFIG")
     if env:
         return _load_json(Path(env))
 
+    # 2) Check for sidecar JSON files
     base = _strip_all_suffixes(path)
     candidates = [
         path.with_name(f"{base}.excel.json"),
@@ -134,9 +138,16 @@ def _load_excel_config(path: Path) -> dict[str, Any]:
         if candidate.exists():
             return _load_json(candidate)
 
+    # 3) Check for parent contribution.json / collection.json
     parent_cfg = _find_contribution_excel_config(path.parent)
     if parent_cfg:
         return parent_cfg
+
+    # 4) Check for plugin instance or class-level override (lowest priority fallback)
+    if plugin is not None:
+        override = getattr(plugin, "_excel_config_override", None)
+        if isinstance(override, dict):
+            return override
 
     return {}
 

--- a/src/bdf/data_sources/maccor_csv.py
+++ b/src/bdf/data_sources/maccor_csv.py
@@ -1,0 +1,58 @@
+# src/bdf/data_sources/maccor_csv.py
+from __future__ import annotations
+
+from .base_delimited import DelimitedTextPlugin
+
+
+class MaccorCSV(DelimitedTextPlugin):
+    """Maccor CSV export. Two metadata header lines followed by the column row.
+    'DPT Time' (DD-Mon-YY H:MM:SS AM/PM) is used for Unix Time / s via augment().
+    Start time can also be extracted from the 'Date of Test:' header line as a fallback.
+    Capacity and Energy columns are net (cumulative per step) values in Ah / Wh.
+    """
+    id = "maccor-csv"
+    exts = (".csv",)
+    default_encoding = "utf-8"
+
+    header_token_patterns = (
+        r"\btest time \(sec\)\b",
+        r"\bvoltage\b",
+        r"\bcurrent\b",
+        r"\bdpt time\b",
+    )
+
+    # DPT Time contains absolute wall-clock timestamps for each row
+    timestamp_candidate_patterns = (
+        r"^dpt\s*time$",
+        r"^date\s*time$",
+    )
+    timestamp_format = "%d-%b-%y %I:%M:%S %p"
+
+    # Extract start time from "Date of Test:,DD-Mon-YY H:MM:SS AM/PM" header line
+    start_time_line_regex = r"Date of Test:\s*,\s*(.+)"
+    start_time_format = "%d-%b-%y %I:%M:%S %p"
+
+    column_synonyms = {
+        "Test Time / s":    ["test time (sec)"],
+        "Step Time / s":    ["step time (sec)"],
+        "Voltage / V":      ["voltage"],
+        "Current / A":      ["current"],
+        "Cycle Count / 1":  ["cycle c"],
+        "Step Index / 1":   ["step"],
+        "Cumulative Capacity / Ah": ["capacity"],
+        "Net Energy / Wh":  ["energy"],
+        "Surface Temperature T1 / degC": ["temp 1", "temperature 1"],
+    }
+
+    unit_column_patterns = {
+        "Test Time / s":    [(r"^test time \(sec\)$", "s")],
+        "Step Time / s":    [(r"^step time \(sec\)$", "s")],
+        "Voltage / V":      [(r"^voltage$", "V")],
+        "Current / A":      [(r"^current$", "A")],
+        "Cumulative Capacity / Ah": [(r"^capacity$", "Ah")], # Cumulative over a step
+        "Cumulative Energy / Wh":  [(r"^energy$", "Wh")], # Cumulative over a step
+        "Surface Temperature T1 / degC": [
+            (r"^temp 1$", "degC"),
+            (r"^temperature 1$", "degC"),
+        ],
+    }

--- a/src/bdf/data_sources/neware_csv.py
+++ b/src/bdf/data_sources/neware_csv.py
@@ -50,8 +50,8 @@ class NewareCSV(DelimitedTextPlugin):
         "Date Time ISO":          ["DateTime", "Datetime", "DATE_TIME"],
 
         # Capacity/energy (kept if present)
-        "Charge Capacity / mAh":    ["Charge Capacity(mAh)", "Chg.Capacity(mAh)"],
-        "Discharge Capacity / mAh": ["Discharge Capacity(mAh)", "DChg.Capacity(mAh)"],
+        "Charge Capacity / mAh":    ["Charge Capacity(mAh)", "Chg.Capacity(mAh)", "Chg. Cap.(mAh)"],
+        "Discharge Capacity / mAh": ["Discharge Capacity(mAh)", "DChg.Capacity(mAh)", "DChg. Cap.(mAh)"],
         "Charge Energy / mWh":      ["Charge Energy(mWh)"],
         "Discharge Energy / mWh":   ["Discharge Energy(mWh)"],
 

--- a/src/bdf/data_sources/neware_csv.py
+++ b/src/bdf/data_sources/neware_csv.py
@@ -57,6 +57,11 @@ class NewareCSV(DelimitedTextPlugin):
 
         # Temperature
         "Ambient Temperature / degC": ["Temperature(°C)", "温度(°C)"],
+        "Surface Temperature T1 / degC": ["T1(°C)"],
+        "Surface Temperature T2 / degC": ["T2(°C)"],
+        "Surface Temperature T3 / degC": ["T3(°C)"],
+        "Surface Temperature T4 / degC": ["T4(°C)"],
+        "Surface Temperature T5 / degC": ["T5(°C)"],
     }
 
     # Units so base .fixup() normalizes to s, V, A, mAh/mWh, degC

--- a/src/bdf/data_sources/neware_csv.py
+++ b/src/bdf/data_sources/neware_csv.py
@@ -10,6 +10,9 @@ class NewareCSV(DelimitedTextPlugin):
     exts = (".csv",)
 
     # Encoding & robustness
+    timestamp_candidate_patterns = (
+        r"^date$", r"^datetime$", r"^date[_\s/:-]*time$",
+    )
     default_encoding = "utf-8-sig"
     encodings_try = ("utf-8", "gb18030", "cp1252", "latin-1")
     ragged_row_policy = "fold_last"
@@ -18,8 +21,8 @@ class NewareCSV(DelimitedTextPlugin):
     header_token_patterns = (
         r"\bVoltage\(V\)\b|\b电压\(V\)\b",
         r"\bCurrent\(A\)\b|\b电流\(A\)\b",
-        r"\bTime\(s\)\b|\b时间\(s\)\b",                 # step time
-        r"\b(Total|Test)\s*Time\(s\)\b|\b总时间\(s\)\b|\b测试时间\(s\)\b",  # test time
+        r"\bTime(?:\(s\))?\b|\b时间\(s\)\b",              # step time (with or without unit)
+        r"\b(Total|Test)\s*Time(?:\(s\))?\b|\b总时间\(s\)\b|\b测试时间\(s\)\b",  # test time
         r"\bDateTime\b|\bDatetime\b",
         r"\bCycle\b",
         r"\bStep\b",
@@ -30,8 +33,9 @@ class NewareCSV(DelimitedTextPlugin):
     column_synonyms = {
         # REQUIRED BDF
         "Test Time / s": [
-            "Total Time(s)", "Test Time(s)", "TotalTime(s)", "TotalTime_S", "Total Time",
-            "总时间(s)", "测试时间(s)"
+            "Total Time(s)", "Test Time(s)", "TotalTime(s)", "TotalTime_S",
+            "总时间(s)", "测试时间(s)",
+            "Total Time",
         ],
         "Voltage / V":   ["Voltage(V)", "电压(V)"],
         "Current / A":   ["Current(A)", "电流(A)"],
@@ -40,7 +44,8 @@ class NewareCSV(DelimitedTextPlugin):
         "Step Time / s": [
             "Time(s)", "Relative Time(s)", "State Time(s)",
             "StepTime(s)", "Step Time(s)", "StepTime_S",
-            "时间(s)"
+            "时间(s)",
+            "Time",
         ],
 
         # Helpful optional columns
@@ -72,6 +77,7 @@ class NewareCSV(DelimitedTextPlugin):
             (r"^TotalTime_S$", "s"),
             (r"^总时间\(s\)$", "s"),
             (r"^测试时间\(s\)$", "s"),
+            (r"^Total Time$", "hms"),
         ],
         "Step Time / s": [
             (r"^Time\(s\)$", "s"),
@@ -81,6 +87,7 @@ class NewareCSV(DelimitedTextPlugin):
             (r"^Step Time\(s\)$", "s"),
             (r"^StepTime_S$", "s"),
             (r"^时间\(s\)$", "s"),
+            (r"^Time$", "hms"),
         ],
         "Voltage / V": [
             (r"^Voltage\(V\)$", "V"),

--- a/src/bdf/data_sources/neware_csv.py
+++ b/src/bdf/data_sources/neware_csv.py
@@ -50,8 +50,8 @@ class NewareCSV(DelimitedTextPlugin):
         "Date Time ISO":          ["DateTime", "Datetime", "DATE_TIME"],
 
         # Capacity/energy (kept if present)
-        "Charge Capacity / mAh":    ["Charge Capacity(mAh)", "Chg.Capacity(mAh)", "Chg. Cap.(mAh)"],
-        "Discharge Capacity / mAh": ["Discharge Capacity(mAh)", "DChg.Capacity(mAh)", "DChg. Cap.(mAh)"],
+        "Charging Capacity / Ah":    ["Charge Capacity(mAh)", "Chg.Capacity(mAh)", "Chg. Cap.(mAh)"],
+        "Discharging Capacity / Ah": ["Discharge Capacity(mAh)", "DChg.Capacity(mAh)", "DChg. Cap.(mAh)"],
         "Charge Energy / mWh":      ["Charge Energy(mWh)"],
         "Discharge Energy / mWh":   ["Discharge Energy(mWh)"],
 
@@ -89,8 +89,8 @@ class NewareCSV(DelimitedTextPlugin):
             (r"^Temperature\(°C\)$", "degC"),
             (r"^温度\(°C\)$", "degC"),
         ],
-        "Charge Capacity / mAh":    [(r"^Charge Capacity\(mAh\)$", "mAh"), (r"^Chg\.Capacity\(mAh\)$", "mAh")],
-        "Discharge Capacity / mAh": [(r"^Discharge Capacity\(mAh\)$", "mAh"), (r"^DChg\.Capacity\(mAh\)$", "mAh")],
+        "Charging Capacity / Ah":    [(r"^Charge Capacity\(mAh\)$", "mAh"), (r"^Chg\.Capacity\(mAh\)$", "mAh"), (r"^Chg\. Cap\.\(mAh\)$", "mAh")],
+        "Discharging Capacity / Ah": [(r"^Discharge Capacity\(mAh\)$", "mAh"), (r"^DChg\.Capacity\(mAh\)$", "mAh"), (r"^DChg\. Cap\.\(mAh\)$", "mAh")],
         "Charge Energy / mWh":      [(r"^Charge Energy\(mWh\)$", "mWh")],
         "Discharge Energy / mWh":   [(r"^Discharge Energy\(mWh\)$", "mWh")],
     }

--- a/src/bdf/data_sources/neware_xlsx.py
+++ b/src/bdf/data_sources/neware_xlsx.py
@@ -1,0 +1,145 @@
+# src/bdf/data_sources/neware_xlsx.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pandas as pd
+
+from .base import CyclerPlugin, SniffResult
+from .excel_xlsx import _default_engine_for
+from .neware_csv import NewareCSV
+
+# Build a single sniff regex from the CSV plugin's header_token_patterns
+_NEWARE_HEADER_RE = re.compile(
+    "|".join(NewareCSV.header_token_patterns), re.IGNORECASE
+)
+
+# Sheet names to try, in priority order
+_RECORD_SHEET_NAMES = ("record", "Record", "RECORD")
+
+
+class NewareXlsx(CyclerPlugin):
+    """Neware/BTS Excel (.xlsx) reader. Reads the 'record' sheet and applies Neware CSV synonyms."""
+
+    id = "neware-xlsx"
+    exts = (".xlsx", ".xlsm", ".xls")
+
+    # Reuse the full Neware CSV synonym and unit maps
+    column_synonyms = NewareCSV.column_synonyms
+    unit_column_patterns = NewareCSV.unit_column_patterns
+    timestamp_candidate_patterns = NewareCSV.timestamp_candidate_patterns
+
+    def sniff(self, path: Path, head: bytes) -> SniffResult:
+        score, reasons = 0.0, []
+        suffix = path.suffix.lower()
+
+        # Must be an Excel file
+        if suffix not in self.exts:
+            return SniffResult(self.id, 0.0, "no-ext", {})
+        score += 0.25
+        reasons.append("ext")
+
+        # ZIP (xlsx) or OLE (xls) magic
+        if head.startswith(b"PK") or head.startswith(b"\xD0\xCF\x11\xE0"):
+            score += 0.15
+            reasons.append("magic")
+
+        # Try to detect Neware-specific content
+        try:
+            sheet = self._find_record_sheet(path)
+            if sheet is not None:
+                # Read just the header row to check for Neware columns
+                df_head = pd.read_excel(
+                    path,
+                    sheet_name=sheet,
+                    nrows=0,
+                    engine=_default_engine_for(path),
+                )
+                cols_joined = " ".join(str(c) for c in df_head.columns)
+                if _NEWARE_HEADER_RE.search(cols_joined):
+                    score += 0.55
+                    reasons.append("neware-headers")
+        except Exception:
+            pass
+
+        return SniffResult(self.id, min(score, 1.0), "+".join(reasons), {})
+
+    def parse(self, path: Path) -> pd.DataFrame:
+        engine = _default_engine_for(path)
+        sheet = self._find_record_sheet(path)
+        if sheet is None:
+            sheet = 0  # fall back to first sheet
+
+        try:
+            df = pd.read_excel(path, sheet_name=sheet, engine=engine)
+        except ImportError as exc:
+            raise RuntimeError(
+                "Reading Excel files requires openpyxl (for .xlsx/.xlsm) or xlrd (for .xls). "
+                "Install with `pip install openpyxl`."
+            ) from exc
+
+        # Clean up headers
+        df.columns = [str(c).strip().lstrip("\ufeff") for c in df.columns]
+
+        # Drop fully empty rows
+        df = df.dropna(how="all")
+
+        # Coerce non-numeric, non-string columns (e.g. datetime.time, Timestamp)
+        # to strings so downstream parsers (augment/fixup) can handle them uniformly
+        for col in df.columns:
+            if pd.api.types.is_numeric_dtype(df[col]):
+                continue
+            if pd.api.types.is_string_dtype(df[col]):
+                continue
+            df[col] = df[col].astype(str)
+
+        return df
+
+    def fixup(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Convert HH:MM:SS duration strings (and Excel epoch-leaked datetimes) to float seconds.
+
+        Excel stores durations as fractional days. For durations < 24h openpyxl
+        returns ``datetime.time`` objects (stringified as ``HH:MM:SS``).  For
+        durations >= 24h it returns ``datetime`` objects relative to the Excel
+        epoch (1899-12-30), stringified as e.g. ``1900-01-06 12:19:42``.
+
+        Strategy: try ``pd.to_datetime`` first (handles both formats with
+        ``format='mixed'``), subtract the Excel epoch.  For any remaining NaT
+        (pure ``HH:MM:SS`` strings without a date part), fall back to
+        ``pd.to_timedelta``.
+        """
+        epoch = pd.Timestamp("1899-12-31")
+
+        for time_col in ("Test Time / s", "Step Time / s"):
+            if time_col not in df.columns or pd.api.types.is_numeric_dtype(df[time_col]):
+                continue
+
+            # 1) Try pd.to_timedelta first (handles bare HH:MM:SS strings)
+            td = pd.to_timedelta(df[time_col], errors="coerce")
+            seconds = td.dt.total_seconds()
+
+            # 2) Fill remaining NaT with epoch-leaked datetime parsing
+            still_nat = seconds.isna()
+            if still_nat.any():
+                dt = pd.to_datetime(
+                    df[time_col][still_nat], errors="coerce", format="mixed"
+                )
+                seconds = seconds.copy()
+                seconds[still_nat] = (dt - epoch).dt.total_seconds()
+
+            if seconds.notna().any():
+                df[time_col] = seconds
+        return df
+
+    @staticmethod
+    def _find_record_sheet(path: Path) -> str | int | None:
+        """Return the 'record' sheet name if it exists, else None."""
+        try:
+            xl = pd.ExcelFile(path, engine=_default_engine_for(path))
+            for name in _RECORD_SHEET_NAMES:
+                if name in xl.sheet_names:
+                    return name
+            return None
+        except Exception:
+            return None

--- a/src/bdf/data_sources/neware_xlsx.py
+++ b/src/bdf/data_sources/neware_xlsx.py
@@ -84,7 +84,6 @@ class NewareXlsx(CyclerPlugin):
 
         # Drop fully empty rows
         df = df.dropna(how="all")
-
         # Coerce non-numeric, non-string columns (e.g. datetime.time, Timestamp)
         # to strings so downstream parsers (augment/fixup) can handle them uniformly
         for col in df.columns:
@@ -94,24 +93,9 @@ class NewareXlsx(CyclerPlugin):
                 continue
             df[col] = df[col].astype(str)
 
-        return df
-
-    def fixup(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Convert HH:MM:SS duration strings (and Excel epoch-leaked datetimes) to float seconds.
-
-        Excel stores durations as fractional days. For durations < 24h openpyxl
-        returns ``datetime.time`` objects (stringified as ``HH:MM:SS``).  For
-        durations >= 24h it returns ``datetime`` objects relative to the Excel
-        epoch (1899-12-30), stringified as e.g. ``1900-01-06 12:19:42``.
-
-        Strategy: try ``pd.to_datetime`` first (handles both formats with
-        ``format='mixed'``), subtract the Excel epoch.  For any remaining NaT
-        (pure ``HH:MM:SS`` strings without a date part), fall back to
-        ``pd.to_timedelta``.
-        """
         epoch = pd.Timestamp("1899-12-31")
 
-        for time_col in ("Test Time / s", "Step Time / s"):
+        for time_col in self.column_synonyms["Step Time / s"] + self.column_synonyms["Test Time / s"]:
             if time_col not in df.columns or pd.api.types.is_numeric_dtype(df[time_col]):
                 continue
 

--- a/src/bdf/data_sources/neware_xlsx.py
+++ b/src/bdf/data_sources/neware_xlsx.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from .base import CyclerPlugin, SniffResult
-from .excel_xlsx import _default_engine_for
+from .excel_xlsx import _default_engine_for, _load_excel_config, _resolve_header, _resolve_sheet
 from .neware_csv import NewareCSV
 
 # Build a single sniff regex from the CSV plugin's header_token_patterns
@@ -29,6 +29,9 @@ class NewareXlsx(CyclerPlugin):
     column_synonyms = NewareCSV.column_synonyms
     unit_column_patterns = NewareCSV.unit_column_patterns
     timestamp_candidate_patterns = NewareCSV.timestamp_candidate_patterns
+    
+    # Optional config override (set programmatically)
+    _excel_config_override = None
 
     def sniff(self, path: Path, head: bytes) -> SniffResult:
         score, reasons = 0.0, []
@@ -66,7 +69,8 @@ class NewareXlsx(CyclerPlugin):
         return SniffResult(self.id, min(score, 1.0), "+".join(reasons), {})
 
     def parse(self, path: Path) -> pd.DataFrame:
-        engine = _default_engine_for(path)
+        cfg = _load_excel_config(path, plugin=self)
+        engine = cfg.get("engine") or _default_engine_for(path)
         sheet = self._find_record_sheet(path)
         if sheet is None:
             sheet = 0  # fall back to first sheet
@@ -116,11 +120,11 @@ class NewareXlsx(CyclerPlugin):
                 df[time_col] = seconds
         return df
 
-    @staticmethod
-    def _find_record_sheet(path: Path) -> str | int | None:
+    def _find_record_sheet(self, path: Path) -> str | int | None:
         """Return the 'record' sheet name if it exists, else None."""
+        cfg = _load_excel_config(path, plugin=self)
         try:
-            xl = pd.ExcelFile(path, engine=_default_engine_for(path))
+            xl = pd.ExcelFile(path, engine=cfg.get("engine") or _default_engine_for(path))
             for name in _RECORD_SHEET_NAMES:
                 if name in xl.sheet_names:
                     return name

--- a/src/bdf/normalize/normalize.py
+++ b/src/bdf/normalize/normalize.py
@@ -14,6 +14,9 @@ from bdf.units import convert_series, parse_from_header
 from . import spec
 
 _SLUG = re.compile(r"[^a-z0-9]+")
+_HMS_DURATION = re.compile(r"^\d{1,3}:\d{2}:\d{2}(?:\.\d+)?$")
+
+
 def _slugify(s: str) -> str:
     return _SLUG.sub("-", s.lower()).strip("-")
 
@@ -117,6 +120,25 @@ def _legacy_alias_index() -> dict[str, object]:
 def _is_numeric_series(s: pd.Series) -> bool:
     return pd.api.types.is_numeric_dtype(s)
 
+
+def _is_hms_duration_series(s: pd.Series) -> bool:
+    """Return True when all non-null values match HH:MM:SS(.f)."""
+    if _is_numeric_series(s):
+        return False
+
+    if pd.api.types.is_timedelta64_dtype(s):
+        return True
+
+    # Only attempt HMS regex matching for string-like/object values.
+    if not (pd.api.types.is_string_dtype(s.dtype) or pd.api.types.is_object_dtype(s.dtype)):
+        return False
+
+    s_str = s.astype("string").str.strip()
+    non_null = s_str.notna()
+    if not non_null.any():
+        return False
+    return bool(s_str[non_null].str.fullmatch(_HMS_DURATION).all())
+
 def _coerce_with_decimal(s: pd.Series, decimal_hint: str | None) -> pd.Series:
     if pd.api.types.is_numeric_dtype(s):
         return s
@@ -155,6 +177,40 @@ def _coalesce_into(target: pd.Series, incoming: pd.Series) -> pd.Series:
 
     # general 'fill holes'
     return target.where(target.notna(), incoming)
+
+
+def _enforce_normalized_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    """Enforce normalized numeric dtypes: '/ 1' -> Int64, other unit columns -> float64."""
+    out = df.copy()
+    duration_cols = {"Test Time / s", "Step Time / s"}
+    for col in out.columns:
+        if " / " not in str(col):
+            continue
+
+        unit = str(col).rsplit(" / ", 1)[-1].strip()
+        s = out[col]
+
+        # Time columns: only use duration parsing for HH:MM:SS(.f)-like values.
+        if str(col) in duration_cols:
+            if pd.api.types.is_timedelta64_dtype(s):
+                s = s.dt.total_seconds()
+            elif not _is_numeric_series(s):
+                if _is_hms_duration_series(s):
+                    s = pd.to_timedelta(s, errors="coerce").dt.total_seconds()
+                else:
+                    s = pd.to_numeric(s, errors="coerce")
+            out[col] = s.astype("float64")
+            continue
+
+        # If already numeric, use as-is; otherwise parse plain numeric values.
+        nums = s if _is_numeric_series(s) else pd.to_numeric(s, errors="coerce")
+
+        if unit == "1":
+            out[col] = nums.round().astype("Int64")
+            continue
+
+        out[col] = nums.astype("float64")
+    return out
 
 def normalize_columns(
     df: pd.DataFrame,
@@ -323,6 +379,7 @@ def normalize_columns(
     front = [c for c in ORDERED_REQUIRED if c in candidate]
     tail  = [c for c in candidate if c not in ORDERED_REQUIRED]
     out = out[front + tail].copy()
+    out = _enforce_normalized_dtypes(out)
 
     out.attrs["bdf:columns"] = meta
     if legacy_headers:

--- a/src/bdf/time.py
+++ b/src/bdf/time.py
@@ -69,11 +69,16 @@ def _datetime_to_unix(dt: pd.Series, *, min_success: float) -> pd.Series:
 
     valid = dt.notna().to_numpy()
     epoch_s = np.full(len(dt), np.nan, dtype="float64")
+
+    # Determine divisor from datetime64 resolution (ns, us, ms, s)
+    reso = getattr(dt.dtype, "unit", "ns")
+    divisor = {"s": 1, "ms": 1e3, "us": 1e6, "ns": 1e9}.get(str(reso), 1e9)
+
     try:
-        epoch_ns_valid = dt.astype("int64")[valid]
+        int_valid = dt.astype("int64")[valid]
     except TypeError:
-        epoch_ns_valid = dt.view("int64")[valid]
-    epoch_s[valid] = epoch_ns_valid.astype("float64") / 1_000_000_000.0
+        int_valid = dt.view("int64")[valid]
+    epoch_s[valid] = int_valid.astype("float64") / divisor
     return pd.Series(epoch_s, index=dt.index, name="Unix Time / s")
 
 

--- a/tests/unit/test_header_start_time.py
+++ b/tests/unit/test_header_start_time.py
@@ -1,0 +1,219 @@
+# tests/unit/test_header_start_time.py
+"""Tests for header start-time extraction in DelimitedTextPlugin."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from bdf.data_sources.base_delimited import DelimitedTextPlugin
+from bdf.data_sources.basytec_txt import BasytecTxt
+from bdf.data_sources.biologic_mpt import BioLogicMPT
+
+
+# Minimal concrete plugin for infrastructure tests
+class _Plugin(DelimitedTextPlugin):
+    id = "_test-start-time"
+    exts = (".txt",)
+    column_synonyms = {
+        "Test Time / s": ["time[s]"],
+        "Voltage / V": ["u[v]"],
+        "Current / A": ["i[a]"],
+    }
+    start_time_line_regex = r"Start:\s*(.+)"
+    start_time_format = "%d.%m.%Y %H:%M:%S"
+
+    def sniff(self, path, head):
+        from bdf.data_sources.base import SniffResult
+        return SniffResult(self.id, 0.0, "", {})
+
+
+def _write_txt(path, header_lines, data_lines, sep="\t"):
+    """Write a minimal delimited text file with a header block."""
+    with open(path, "w", encoding="utf-8") as f:
+        for line in header_lines:
+            f.write(line + "\n")
+        f.write(sep.join(data_lines[0]) + "\n")
+        for row in data_lines[1:]:
+            f.write(sep.join(row) + "\n")
+
+
+# _extract_start_time unit tests
+
+class TestExtractStartTime:
+    def setup_method(self):
+        self.plugin = _Plugin()
+
+    def test_finds_start_time(self, tmp_path):
+        p = tmp_path / "data.txt"
+        p.write_text("Start: 09.03.2026 11:35:38\nTime[s]\tU[V]\n0\t3.7\n")
+        result = self.plugin._extract_start_time(p, "utf-8")
+        expected = pd.Timestamp("2026-03-09 11:35:38", tz="UTC").timestamp()
+        assert result == pytest.approx(expected)
+
+    def test_returns_none_when_regex_not_set(self, tmp_path):
+        p = tmp_path / "data.txt"
+        p.write_text("Start: 09.03.2026 11:35:38\nTime[s]\tU[V]\n0\t3.7\n")
+        plugin = _Plugin()
+        plugin.start_time_line_regex = None
+        result = plugin._extract_start_time(p, "utf-8")
+        assert result is None
+
+    def test_returns_none_when_format_not_set(self, tmp_path):
+        p = tmp_path / "data.txt"
+        p.write_text("Start: 09.03.2026 11:35:38\nTime[s]\tU[V]\n0\t3.7\n")
+        plugin = _Plugin()
+        plugin.start_time_format = None
+        result = plugin._extract_start_time(p, "utf-8")
+        assert result is None
+
+    def test_returns_none_when_no_match(self, tmp_path):
+        p = tmp_path / "data.txt"
+        p.write_text("No start time here\nTime[s]\tU[V]\n0\t3.7\n")
+        result = self.plugin._extract_start_time(p, "utf-8")
+        assert result is None
+
+    def test_returns_none_on_unparseable_value(self, tmp_path):
+        p = tmp_path / "data.txt"
+        p.write_text("Start: not-a-date\nTime[s]\tU[V]\n0\t3.7\n")
+        result = self.plugin._extract_start_time(p, "utf-8")
+        assert result is None
+
+    def test_uses_assume_naive_tz(self, tmp_path):
+        p = tmp_path / "data.txt"
+        p.write_text("Start: 09.03.2026 11:35:38\nTime[s]\tU[V]\n0\t3.7\n")
+        plugin = _Plugin()
+        plugin.assume_naive_tz = "Europe/London"
+        result = plugin._extract_start_time(p, "utf-8")
+        expected = pd.Timestamp("2026-03-09 11:35:38", tz="Europe/London").tz_convert("UTC").timestamp()
+        assert result == pytest.approx(expected)
+
+
+# fixup() Unix Time derivation
+
+class TestFixupUnixTime:
+    def setup_method(self):
+        self.plugin = _Plugin()
+
+    def test_adds_unix_time_from_start_time(self):
+        self.plugin._start_time_epoch = 1000.0
+        self.plugin._unit_hints = {}
+        df = pd.DataFrame({"Test Time / s": [0.0, 1.0, 2.0], "Voltage / V": [3.7, 3.8, 3.9]})
+        result = self.plugin.fixup(df)
+        assert "Unix Time / s" in result.columns
+        assert list(result["Unix Time / s"]) == [1000.0, 1001.0, 1002.0]
+
+    def test_skips_if_unix_time_already_present(self):
+        self.plugin._start_time_epoch = 1000.0
+        self.plugin._unit_hints = {}
+        df = pd.DataFrame({
+            "Test Time / s": [0.0, 1.0],
+            "Voltage / V": [3.7, 3.8],
+            "Unix Time / s": [9999.0, 10000.0],
+        })
+        result = self.plugin.fixup(df)
+        assert list(result["Unix Time / s"]) == [9999.0, 10000.0]
+
+    def test_skips_if_no_start_time_epoch(self):
+        self.plugin._start_time_epoch = None
+        self.plugin._unit_hints = {}
+        df = pd.DataFrame({"Test Time / s": [0.0, 1.0], "Voltage / V": [3.7, 3.8]})
+        result = self.plugin.fixup(df)
+        assert "Unix Time / s" not in result.columns
+
+    def test_skips_if_no_test_time_column(self):
+        self.plugin._start_time_epoch = 1000.0
+        self.plugin._unit_hints = {}
+        df = pd.DataFrame({"Voltage / V": [3.7, 3.8]})
+        result = self.plugin.fixup(df)
+        assert "Unix Time / s" not in result.columns
+
+
+# Full parse → fixup pipeline with synthetic files
+
+class TestFullPipeline:
+    def test_basytec_derives_unix_time(self, tmp_path):
+        """Basytec file with ~Start of Test header produces Unix Time / s."""
+        import bdf
+
+        p = tmp_path / "data.txt"
+        p.write_text(
+            "Basytec battery test system\n"
+            "~Start of Test: 09.03.2026 11:35:38\n"
+            "~Time[s]\t~U[V]\t~I[A]\n"
+            "0\t3.700\t1.000\n"
+            "1\t3.750\t1.000\n"
+            "10\t3.800\t1.000\n",
+            encoding="latin-1",
+        )
+        out = bdf.read(p, include_optional=True)
+        assert "Unix Time / s" in out.columns
+        assert out["Unix Time / s"].dtype == np.float64
+        expected_t0 = pd.Timestamp("2026-03-09 11:35:38", tz="UTC").timestamp()
+        assert out["Unix Time / s"].iloc[0] == pytest.approx(expected_t0)
+        assert out["Unix Time / s"].iloc[1] == pytest.approx(expected_t0 + 1.0)
+        assert out["Unix Time / s"].iloc[2] == pytest.approx(expected_t0 + 10.0)
+
+    def test_biologic_derives_unix_time(self, tmp_path):
+        """BioLogic MPT file with 'Acquisition started on' header produces Unix Time / s."""
+        import bdf
+
+        p = tmp_path / "data.mpt"
+        p.write_text(
+            "BT-Lab ASCII FILE\n"
+            "Nb header lines : 5\n"
+            "Acquisition started on : 03/09/2026 11:35:38.000\n"
+            "\n"
+            "time/s\tEwe/V\tI/mA\n"
+            "0,000\t3,700\t100,000\n"
+            "1,000\t3,750\t100,000\n"
+            "10,000\t3,800\t100,000\n",
+            encoding="latin-1",
+        )
+        out = bdf.read(p, include_optional=True)
+        assert "Unix Time / s" in out.columns
+        assert pd.api.types.is_float_dtype(out["Unix Time / s"])
+        expected_t0 = pd.Timestamp("2026-03-09 11:35:38", tz="UTC").timestamp()
+        assert out["Unix Time / s"].iloc[0] == pytest.approx(expected_t0)
+        assert out["Unix Time / s"].iloc[2] == pytest.approx(expected_t0 + 10.0)
+
+    def test_no_start_time_header_no_unix_time(self, tmp_path):
+        """File without a start time header should not produce Unix Time / s."""
+        import bdf
+
+        p = tmp_path / "data.txt"
+        p.write_text(
+            "Basytec battery test system\n"
+            "~Time[s]\t~U[V]\t~I[A]\n"
+            "0\t3.700\t1.000\n"
+            "1\t3.750\t1.000\n",
+            encoding="latin-1",
+        )
+        out = bdf.read(p, include_optional=True)
+        assert "Unix Time / s" not in out.columns
+
+
+# Plugin attribute declarations
+
+class TestPluginAttributes:
+    def test_basytec_has_start_time_regex(self):
+        assert BasytecTxt.start_time_line_regex is not None
+        assert BasytecTxt.start_time_format == "%d.%m.%Y %H:%M:%S"
+
+    def test_biologic_has_start_time_regex(self):
+        assert BioLogicMPT.start_time_line_regex is not None
+        assert BioLogicMPT.start_time_format == "%m/%d/%Y %H:%M:%S.%f"
+
+    def test_basytec_regex_matches_header_line(self):
+        import re
+        pat = re.compile(BasytecTxt.start_time_line_regex, re.IGNORECASE)
+        m = pat.search("~Start of Test: 09.03.2026 11:35:38")
+        assert m is not None
+        assert m.group(1).strip() == "09.03.2026 11:35:38"
+
+    def test_biologic_regex_matches_header_line(self):
+        import re
+        pat = re.compile(BioLogicMPT.start_time_line_regex, re.IGNORECASE)
+        m = pat.search("Acquisition started on : 03/09/2026 11:35:38.000")
+        assert m is not None
+        assert m.group(1).strip() == "03/09/2026 11:35:38.000"

--- a/tests/unit/test_neware_xlsx.py
+++ b/tests/unit/test_neware_xlsx.py
@@ -1,0 +1,369 @@
+# tests/unit/test_neware_xlsx.py
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from bdf.data_sources.neware_xlsx import NewareXlsx
+
+# NewareXlsx class attributes
+
+class TestNewareXlsxAttributes:
+    def test_plugin_id(self):
+        assert NewareXlsx.id == "neware-xlsx"
+
+    def test_exts(self):
+        assert ".xlsx" in NewareXlsx.exts
+        assert ".xlsm" in NewareXlsx.exts
+        assert ".xls" in NewareXlsx.exts
+
+    def test_inherits_csv_synonyms(self):
+        from bdf.data_sources.neware_csv import NewareCSV
+        assert NewareXlsx.column_synonyms is NewareCSV.column_synonyms
+
+    def test_inherits_csv_unit_patterns(self):
+        from bdf.data_sources.neware_csv import NewareCSV
+        assert NewareXlsx.unit_column_patterns is NewareCSV.unit_column_patterns
+
+    def test_inherits_csv_timestamp_patterns(self):
+        from bdf.data_sources.neware_csv import NewareCSV
+        assert NewareXlsx.timestamp_candidate_patterns is NewareCSV.timestamp_candidate_patterns
+
+    def test_timestamp_patterns_include_date(self):
+        """Neware exports a bare 'Date' column for timestamps."""
+        import re
+        pat = re.compile(
+            "|".join(NewareXlsx.timestamp_candidate_patterns), re.IGNORECASE
+        )
+        assert pat.search("date")
+        assert pat.search("DateTime")
+
+
+# sniff()
+
+class TestSniff:
+    def setup_method(self):
+        self.plugin = NewareXlsx()
+
+    def test_rejects_non_excel_ext(self, tmp_path):
+        p = tmp_path / "data.csv"
+        p.write_bytes(b"PK\x03\x04")
+        result = self.plugin.sniff(p, p.read_bytes()[:4096])
+        assert result.confidence == 0.0
+
+    def test_scores_excel_ext(self, tmp_path):
+        p = tmp_path / "data.xlsx"
+        p.write_bytes(b"\x00" * 100)
+        result = self.plugin.sniff(p, p.read_bytes()[:4096])
+        assert result.confidence >= 0.25
+
+    def test_scores_zip_magic(self, tmp_path):
+        p = tmp_path / "data.xlsx"
+        p.write_bytes(b"PK\x03\x04" + b"\x00" * 100)
+        result = self.plugin.sniff(p, p.read_bytes()[:4096])
+        assert result.confidence >= 0.4
+
+    def test_scores_ole_magic(self, tmp_path):
+        p = tmp_path / "data.xls"
+        p.write_bytes(b"\xD0\xCF\x11\xE0" + b"\x00" * 100)
+        result = self.plugin.sniff(p, p.read_bytes()[:4096])
+        assert result.confidence >= 0.4
+
+
+# parse() with synthetic Excel files
+
+def _write_neware_xlsx(path: Path, df: pd.DataFrame, sheet_name: str = "record"):
+    """Write a DataFrame to an Excel file mimicking Neware output."""
+    df.to_excel(path, sheet_name=sheet_name, index=False, engine="openpyxl")
+
+
+class TestParse:
+    def setup_method(self):
+        self.plugin = NewareXlsx()
+
+    def test_reads_record_sheet(self, tmp_path):
+        df = pd.DataFrame({
+            "Total Time": [0.0, 1.0, 2.0],
+            "Voltage(V)": [3.7, 3.8, 3.9],
+            "Current(mA)": [100.0, 100.0, 100.0],
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        result = self.plugin.parse(p)
+        assert "Total Time" in result.columns
+        assert "Voltage(V)" in result.columns
+        assert len(result) == 3
+
+    def test_falls_back_to_first_sheet(self, tmp_path):
+        df = pd.DataFrame({
+            "Total Time": [0.0, 1.0],
+            "Voltage(V)": [3.7, 3.8],
+            "Current(mA)": [100.0, 100.0],
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="Sheet1")
+
+        result = self.plugin.parse(p)
+        assert "Total Time" in result.columns
+
+    def test_coerces_datetime_time_to_string(self, tmp_path):
+        """datetime.time objects from Excel should be coerced to strings for downstream parsers."""
+        df = pd.DataFrame({
+            "Total Time": [datetime.time(0, 0, 0), datetime.time(0, 0, 5)],
+            "Voltage(V)": [3.7, 3.8],
+            "Current(mA)": [100.0, 100.0],
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        result = self.plugin.parse(p)
+        # Should be string, not datetime.time objects
+        assert pd.api.types.is_string_dtype(result["Total Time"])
+
+    def test_coerces_timestamp_to_string(self, tmp_path):
+        """Timestamp objects (e.g. Date column) should be coerced to strings."""
+        df = pd.DataFrame({
+            "Total Time": [0.0, 1.0],
+            "Voltage(V)": [3.7, 3.8],
+            "Date": pd.to_datetime(["2026-03-09 11:35:38", "2026-03-09 11:35:39"]),
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        result = self.plugin.parse(p)
+        assert pd.api.types.is_string_dtype(result["Date"])
+
+    def test_strips_bom_from_headers(self, tmp_path):
+        df = pd.DataFrame({"\ufeffVoltage(V)": [3.7], "Current(mA)": [100.0]})
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        result = self.plugin.parse(p)
+        assert "Voltage(V)" in result.columns
+
+    def test_drops_fully_empty_rows(self, tmp_path):
+        df = pd.DataFrame({
+            "Total Time": [0.0, None, 2.0],
+            "Voltage(V)": [3.7, None, 3.9],
+            "Current(mA)": [100.0, None, 100.0],
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        result = self.plugin.parse(p)
+        assert len(result) == 2
+
+
+# fixup()
+
+class TestFixup:
+    def setup_method(self):
+        self.plugin = NewareXlsx()
+
+    def test_converts_hms_strings_to_seconds(self):
+        df = pd.DataFrame({
+            "Test Time / s": ["00:00:00.000", "00:00:05.000", "01:00:00.000"],
+            "Voltage / V": [3.7, 3.8, 3.9],
+        })
+        result = self.plugin.fixup(df)
+        assert result["Test Time / s"].dtype == np.float64
+        assert result["Test Time / s"].iloc[0] == 0.0
+        assert result["Test Time / s"].iloc[1] == 5.0
+        assert result["Test Time / s"].iloc[2] == 3600.0
+
+    def test_leaves_numeric_time_untouched(self):
+        df = pd.DataFrame({
+            "Test Time / s": [0.0, 5.0, 3600.0],
+            "Voltage / V": [3.7, 3.8, 3.9],
+        })
+        result = self.plugin.fixup(df)
+        assert list(result["Test Time / s"]) == [0.0, 5.0, 3600.0]
+
+    def test_handles_non_time_strings_gracefully(self):
+        """Non-time strings should not crash fixup."""
+        df = pd.DataFrame({
+            "Test Time / s": ["not", "a", "time"],
+            "Voltage / V": [3.7, 3.8, 3.9],
+        })
+        result = self.plugin.fixup(df)
+        # to_timedelta returns all NaT, notna().any() is False → no conversion
+        assert list(result["Test Time / s"]) == ["not", "a", "time"]
+
+    def test_converts_epoch_leaked_datetimes(self):
+        """Durations >= 24h appear as Excel-epoch datetimes (1899-12-31 based)."""
+        df = pd.DataFrame({
+            "Test Time / s": [
+                "1900-01-01 00:00:00.900000",  # 1 day + 0.9s = 86400.9
+                "1900-01-06 12:19:42.500000",  # 6 days 12:19:42.5 = 562782.5
+            ],
+            "Voltage / V": [3.7, 3.8],
+        })
+        result = self.plugin.fixup(df)
+        assert result["Test Time / s"].dtype == np.float64
+        assert np.isclose(result["Test Time / s"].iloc[0], 86400.9)
+        assert np.isclose(result["Test Time / s"].iloc[1], 562782.5)
+
+    def test_converts_mixed_hms_and_epoch_leaked(self):
+        """Real Neware files mix HH:MM:SS (< 24h) and epoch-leaked datetimes (>= 24h)."""
+        df = pd.DataFrame({
+            "Test Time / s": [
+                "00:00:00",                     # 0s (bare HH:MM:SS)
+                "12:30:00",                     # 45000s
+                "1900-01-01 00:00:05.000000",   # 1 day + 5s = 86405s
+            ],
+            "Voltage / V": [3.7, 3.8, 3.9],
+        })
+        result = self.plugin.fixup(df)
+        assert result["Test Time / s"].dtype == np.float64
+        assert result["Test Time / s"].iloc[0] == 0.0
+        assert result["Test Time / s"].iloc[1] == 45000.0
+        assert np.isclose(result["Test Time / s"].iloc[2], 86405.0)
+
+    def test_epoch_leaked_continuity_at_24h_boundary(self):
+        """Test Time must be continuous across the 24h boundary where Excel switches formats.
+
+        Below 24h openpyxl returns datetime.time → HH:MM:SS strings.
+        At/above 24h it returns datetime objects from epoch 1899-12-31.
+        The transition must not introduce a ~86400s jump.
+        """
+        df = pd.DataFrame({
+            "Test Time / s": [
+                "23:59:58",                     # 86398s
+                "23:59:59",                     # 86399s
+                "1900-01-01 00:00:00.000000",   # 24h exactly = 86400s
+                "1900-01-01 00:00:01.000000",   # 86401s
+            ],
+            "Voltage / V": [3.7, 3.8, 3.9, 4.0],
+        })
+        result = self.plugin.fixup(df)
+        seconds = result["Test Time / s"]
+        assert seconds.dtype == np.float64
+        assert seconds.iloc[0] == 86398.0
+        assert seconds.iloc[1] == 86399.0
+        assert seconds.iloc[2] == 86400.0
+        assert seconds.iloc[3] == 86401.0
+        # Verify no jump > 2s between consecutive rows
+        diffs = seconds.diff().dropna()
+        assert (diffs <= 2.0).all(), f"Discontinuity at 24h boundary: {diffs.tolist()}"
+
+    def test_skips_missing_time_columns(self):
+        df = pd.DataFrame({"Voltage / V": [3.7, 3.8]})
+        result = self.plugin.fixup(df)
+        assert "Test Time / s" not in result.columns
+
+
+# Full pipeline: parse → augment → normalize → fixup
+
+class TestFullPipeline:
+    def test_numeric_time_columns(self, tmp_path):
+        """Standard case: Total Time as numeric seconds."""
+        import bdf
+
+        df = pd.DataFrame({
+            "Total Time": [0.0, 1.5, 3.0],
+            "Voltage(V)": [3.7, 3.8, 3.9],
+            "Current(mA)": [100.0, 200.0, 300.0],
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        out = bdf.read(p)
+        assert "Test Time / s" in out.columns
+        assert "Voltage / V" in out.columns
+        assert "Current / A" in out.columns
+        assert out["Test Time / s"].dtype == np.float64
+        assert list(out["Test Time / s"]) == [0.0, 1.5, 3.0]
+
+    def test_hms_string_time_columns_converted(self, tmp_path):
+        """HH:MM:SS strings should be converted to float seconds via fixup()."""
+        import bdf
+
+        df = pd.DataFrame({
+            "Total Time": ["00:00:00.000", "00:00:05.000"],
+            "Voltage(V)": [3.7, 3.8],
+            "Current(mA)": [100.0, 200.0],
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        out = bdf.read(p)
+        assert out["Test Time / s"].dtype == np.float64
+        assert out["Test Time / s"].iloc[0] == 0.0
+        assert out["Test Time / s"].iloc[1] == 5.0
+
+    def test_date_column_becomes_unix_time(self, tmp_path):
+        """The 'Date' column should be converted to Unix Time / s via augment()."""
+        import bdf
+
+        df = pd.DataFrame({
+            "Total Time": [0.0, 1.0],
+            "Voltage(V)": [3.7, 3.8],
+            "Current(mA)": [100.0, 200.0],
+            "Date": pd.to_datetime(["2026-03-09 11:35:38", "2026-03-09 11:35:39"]),
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        out = bdf.read(p, include_optional=True)
+        assert "Unix Time / s" in out.columns
+        assert out["Unix Time / s"].dtype == np.float64
+        # Verify values are plausible epoch seconds (year 2026 ≈ 1.77e9)
+        assert out["Unix Time / s"].iloc[0] > 1.7e9
+
+    def test_current_ma_scaled_to_amps(self, tmp_path):
+        """Current(mA) header should be converted to Amps."""
+        import bdf
+
+        df = pd.DataFrame({
+            "Total Time": [0.0, 1.0],
+            "Voltage(V)": [3.7, 3.8],
+            "Current(mA)": [500.0, -500.0],
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        out = bdf.read(p)
+        # Current(mA) → Current / A: 500 mA = 0.5 A
+        assert np.isclose(out["Current / A"].iloc[0], 0.5)
+        assert np.isclose(out["Current / A"].iloc[1], -0.5)
+
+    def test_capacity_columns_preserved(self, tmp_path):
+        """Charging/discharging capacity should come through."""
+        import bdf
+
+        df = pd.DataFrame({
+            "Total Time": [0.0, 1.0],
+            "Voltage(V)": [3.7, 3.8],
+            "Current(mA)": [100.0, 200.0],
+            "Chg. Cap.(mAh)": [10.0, 20.0],
+            "DChg. Cap.(mAh)": [5.0, 15.0],
+        })
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
+
+        out = bdf.read(p, include_optional=True)
+        assert "Charging Capacity / Ah" in out.columns
+        assert "Discharging Capacity / Ah" in out.columns
+
+
+# _find_record_sheet
+
+class TestFindRecordSheet:
+    def test_finds_record_sheet(self, tmp_path):
+        p = tmp_path / "test.xlsx"
+        pd.DataFrame({"A": [1]}).to_excel(p, sheet_name="record", index=False)
+        assert NewareXlsx._find_record_sheet(p) == "record"
+
+    def test_returns_none_without_record_sheet(self, tmp_path):
+        p = tmp_path / "test.xlsx"
+        pd.DataFrame({"A": [1]}).to_excel(p, sheet_name="data", index=False)
+        assert NewareXlsx._find_record_sheet(p) is None
+
+    def test_returns_none_for_invalid_file(self, tmp_path):
+        p = tmp_path / "bad.xlsx"
+        p.write_bytes(b"not an excel file")
+        assert NewareXlsx._find_record_sheet(p) is None

--- a/tests/unit/test_neware_xlsx.py
+++ b/tests/unit/test_neware_xlsx.py
@@ -332,16 +332,16 @@ class TestFindRecordSheet:
         """Finds the record sheet when present."""
         p = tmp_path / "test.xlsx"
         pd.DataFrame({"A": [1]}).to_excel(p, sheet_name="record", index=False)
-        assert NewareXlsx._find_record_sheet(p) == "record"
+        assert NewareXlsx()._find_record_sheet(p) == "record"
 
     def test_returns_none_without_record_sheet(self, tmp_path):
         """Returns None when no record sheet exists."""
         p = tmp_path / "test.xlsx"
         pd.DataFrame({"A": [1]}).to_excel(p, sheet_name="data", index=False)
-        assert NewareXlsx._find_record_sheet(p) is None
+        assert NewareXlsx()._find_record_sheet(p) is None
 
     def test_returns_none_for_invalid_file(self, tmp_path):
         """Returns None for unreadable Excel files."""
         p = tmp_path / "bad.xlsx"
         p.write_bytes(b"not an excel file")
-        assert NewareXlsx._find_record_sheet(p) is None
+        assert NewareXlsx()._find_record_sheet(p) is None

--- a/tests/unit/test_neware_xlsx.py
+++ b/tests/unit/test_neware_xlsx.py
@@ -1,5 +1,6 @@
 # tests/unit/test_neware_xlsx.py
 from __future__ import annotations
+import pytest
 
 import datetime
 from pathlib import Path
@@ -13,22 +14,27 @@ from bdf.data_sources.neware_xlsx import NewareXlsx
 
 class TestNewareXlsxAttributes:
     def test_plugin_id(self):
+        """Uses the expected plugin identifier."""
         assert NewareXlsx.id == "neware-xlsx"
 
     def test_exts(self):
+        """Declares supported Excel file extensions."""
         assert ".xlsx" in NewareXlsx.exts
         assert ".xlsm" in NewareXlsx.exts
         assert ".xls" in NewareXlsx.exts
 
     def test_inherits_csv_synonyms(self):
+        """Reuses column synonym mappings from the CSV plugin."""
         from bdf.data_sources.neware_csv import NewareCSV
         assert NewareXlsx.column_synonyms is NewareCSV.column_synonyms
 
     def test_inherits_csv_unit_patterns(self):
+        """Reuses unit-column patterns from the CSV plugin."""
         from bdf.data_sources.neware_csv import NewareCSV
         assert NewareXlsx.unit_column_patterns is NewareCSV.unit_column_patterns
 
     def test_inherits_csv_timestamp_patterns(self):
+        """Reuses timestamp candidate patterns from the CSV plugin."""
         from bdf.data_sources.neware_csv import NewareCSV
         assert NewareXlsx.timestamp_candidate_patterns is NewareCSV.timestamp_candidate_patterns
 
@@ -49,24 +55,28 @@ class TestSniff:
         self.plugin = NewareXlsx()
 
     def test_rejects_non_excel_ext(self, tmp_path):
+        """Returns zero confidence for non-Excel extensions."""
         p = tmp_path / "data.csv"
         p.write_bytes(b"PK\x03\x04")
         result = self.plugin.sniff(p, p.read_bytes()[:4096])
         assert result.confidence == 0.0
 
     def test_scores_excel_ext(self, tmp_path):
+        """Awards extension-based confidence for Excel files."""
         p = tmp_path / "data.xlsx"
         p.write_bytes(b"\x00" * 100)
         result = self.plugin.sniff(p, p.read_bytes()[:4096])
         assert result.confidence >= 0.25
 
     def test_scores_zip_magic(self, tmp_path):
+        """Awards magic-byte confidence for ZIP-based Excel files."""
         p = tmp_path / "data.xlsx"
         p.write_bytes(b"PK\x03\x04" + b"\x00" * 100)
         result = self.plugin.sniff(p, p.read_bytes()[:4096])
         assert result.confidence >= 0.4
 
     def test_scores_ole_magic(self, tmp_path):
+        """Awards magic-byte confidence for OLE-based Excel files."""
         p = tmp_path / "data.xls"
         p.write_bytes(b"\xD0\xCF\x11\xE0" + b"\x00" * 100)
         result = self.plugin.sniff(p, p.read_bytes()[:4096])
@@ -85,6 +95,7 @@ class TestParse:
         self.plugin = NewareXlsx()
 
     def test_reads_record_sheet(self, tmp_path):
+        """Reads data from the preferred record sheet."""
         df = pd.DataFrame({
             "Total Time": [0.0, 1.0, 2.0],
             "Voltage(V)": [3.7, 3.8, 3.9],
@@ -99,6 +110,7 @@ class TestParse:
         assert len(result) == 3
 
     def test_falls_back_to_first_sheet(self, tmp_path):
+        """Falls back to the first sheet when record is absent."""
         df = pd.DataFrame({
             "Total Time": [0.0, 1.0],
             "Voltage(V)": [3.7, 3.8],
@@ -110,8 +122,8 @@ class TestParse:
         result = self.plugin.parse(p)
         assert "Total Time" in result.columns
 
-    def test_coerces_datetime_time_to_string(self, tmp_path):
-        """datetime.time objects from Excel should be coerced to strings for downstream parsers."""
+    def test_coerces_datetime_time_to_float(self, tmp_path):
+        """datetime.time values from Excel should be normalized to numeric seconds."""
         df = pd.DataFrame({
             "Total Time": [datetime.time(0, 0, 0), datetime.time(0, 0, 5)],
             "Voltage(V)": [3.7, 3.8],
@@ -121,8 +133,9 @@ class TestParse:
         _write_neware_xlsx(p, df, sheet_name="record")
 
         result = self.plugin.parse(p)
-        # Should be string, not datetime.time objects
-        assert pd.api.types.is_string_dtype(result["Total Time"])
+        assert result["Total Time"].dtype == np.float64
+        assert result["Total Time"].iloc[0] == 0.0
+        assert result["Total Time"].iloc[1] == 5.0
 
     def test_coerces_timestamp_to_string(self, tmp_path):
         """Timestamp objects (e.g. Date column) should be coerced to strings."""
@@ -137,15 +150,8 @@ class TestParse:
         result = self.plugin.parse(p)
         assert pd.api.types.is_string_dtype(result["Date"])
 
-    def test_strips_bom_from_headers(self, tmp_path):
-        df = pd.DataFrame({"\ufeffVoltage(V)": [3.7], "Current(mA)": [100.0]})
-        p = tmp_path / "neware.xlsx"
-        _write_neware_xlsx(p, df, sheet_name="record")
-
-        result = self.plugin.parse(p)
-        assert "Voltage(V)" in result.columns
-
     def test_drops_fully_empty_rows(self, tmp_path):
+        """Drops rows that are fully empty after parsing."""
         df = pd.DataFrame({
             "Total Time": [0.0, None, 2.0],
             "Voltage(V)": [3.7, None, 3.9],
@@ -157,104 +163,71 @@ class TestParse:
         result = self.plugin.parse(p)
         assert len(result) == 2
 
+    def test_parse_converts_epoch_leaked_datetimes(self, tmp_path):
+        """parse() converts epoch-leaked datetime strings into float seconds."""
+        df = pd.DataFrame(
+            {
+                "Total Time": [
+                    "1900-01-01 00:00:00.900000",  # 1 day + 0.9s = 86400.9
+                    "1900-01-06 12:19:42.500000",  # 6 days 12:19:42.5 = 562782.5
+                ],
+                "Voltage(V)": [3.7, 3.8],
+                "Current(mA)": [100.0, 100.0],
+            }
+        )
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
 
-# fixup()
+        result = self.plugin.parse(p)
+        assert np.isclose(result["Total Time"].iloc[0], 86400.9)
+        assert np.isclose(result["Total Time"].iloc[1], 562782.5)
 
-class TestFixup:
-    def setup_method(self):
-        self.plugin = NewareXlsx()
+    def test_parse_converts_mixed_hms_and_epoch_leaked(self, tmp_path):
+        """parse() handles mixed HH:MM:SS and epoch-leaked datetime strings."""
+        df = pd.DataFrame(
+            {
+                "Total Time": [
+                    "00:00:00",  # 0s
+                    "12:30:00",  # 45000s
+                    "1900-01-01 00:00:05.000000",  # 86405s
+                ],
+                "Voltage(V)": [3.7, 3.8, 3.9],
+                "Current(mA)": [100.0, 100.0, 100.0],
+            }
+        )
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
 
-    def test_converts_hms_strings_to_seconds(self):
-        df = pd.DataFrame({
-            "Test Time / s": ["00:00:00.000", "00:00:05.000", "01:00:00.000"],
-            "Voltage / V": [3.7, 3.8, 3.9],
-        })
-        result = self.plugin.fixup(df)
-        assert result["Test Time / s"].dtype == np.float64
-        assert result["Test Time / s"].iloc[0] == 0.0
-        assert result["Test Time / s"].iloc[1] == 5.0
-        assert result["Test Time / s"].iloc[2] == 3600.0
+        result = self.plugin.parse(p)
+        assert np.isclose(result["Total Time"].iloc[0], 0.0)
+        assert np.isclose(result["Total Time"].iloc[1], 45000.0)
+        assert np.isclose(result["Total Time"].iloc[2], 86405.0)
 
-    def test_leaves_numeric_time_untouched(self):
-        df = pd.DataFrame({
-            "Test Time / s": [0.0, 5.0, 3600.0],
-            "Voltage / V": [3.7, 3.8, 3.9],
-        })
-        result = self.plugin.fixup(df)
-        assert list(result["Test Time / s"]) == [0.0, 5.0, 3600.0]
+    def test_parse_epoch_leaked_continuity_at_24h_boundary(self, tmp_path):
+        """parse() keeps Test Time continuous across the HH:MM:SS/epoch-leaked boundary."""
+        df = pd.DataFrame(
+            {
+                "Total Time": [
+                    "23:59:58",  # 86398s
+                    "23:59:59",  # 86399s
+                    "1900-01-01 00:00:00.000000",  # 86400s
+                    "1900-01-01 00:00:01.000000",  # 86401s
+                ],
+                "Voltage(V)": [3.7, 3.8, 3.9, 4.0],
+                "Current(mA)": [100.0, 100.0, 100.0, 100.0],
+            }
+        )
+        p = tmp_path / "neware.xlsx"
+        _write_neware_xlsx(p, df, sheet_name="record")
 
-    def test_handles_non_time_strings_gracefully(self):
-        """Non-time strings should not crash fixup."""
-        df = pd.DataFrame({
-            "Test Time / s": ["not", "a", "time"],
-            "Voltage / V": [3.7, 3.8, 3.9],
-        })
-        result = self.plugin.fixup(df)
-        # to_timedelta returns all NaT, notna().any() is False → no conversion
-        assert list(result["Test Time / s"]) == ["not", "a", "time"]
-
-    def test_converts_epoch_leaked_datetimes(self):
-        """Durations >= 24h appear as Excel-epoch datetimes (1899-12-31 based)."""
-        df = pd.DataFrame({
-            "Test Time / s": [
-                "1900-01-01 00:00:00.900000",  # 1 day + 0.9s = 86400.9
-                "1900-01-06 12:19:42.500000",  # 6 days 12:19:42.5 = 562782.5
-            ],
-            "Voltage / V": [3.7, 3.8],
-        })
-        result = self.plugin.fixup(df)
-        assert result["Test Time / s"].dtype == np.float64
-        assert np.isclose(result["Test Time / s"].iloc[0], 86400.9)
-        assert np.isclose(result["Test Time / s"].iloc[1], 562782.5)
-
-    def test_converts_mixed_hms_and_epoch_leaked(self):
-        """Real Neware files mix HH:MM:SS (< 24h) and epoch-leaked datetimes (>= 24h)."""
-        df = pd.DataFrame({
-            "Test Time / s": [
-                "00:00:00",                     # 0s (bare HH:MM:SS)
-                "12:30:00",                     # 45000s
-                "1900-01-01 00:00:05.000000",   # 1 day + 5s = 86405s
-            ],
-            "Voltage / V": [3.7, 3.8, 3.9],
-        })
-        result = self.plugin.fixup(df)
-        assert result["Test Time / s"].dtype == np.float64
-        assert result["Test Time / s"].iloc[0] == 0.0
-        assert result["Test Time / s"].iloc[1] == 45000.0
-        assert np.isclose(result["Test Time / s"].iloc[2], 86405.0)
-
-    def test_epoch_leaked_continuity_at_24h_boundary(self):
-        """Test Time must be continuous across the 24h boundary where Excel switches formats.
-
-        Below 24h openpyxl returns datetime.time → HH:MM:SS strings.
-        At/above 24h it returns datetime objects from epoch 1899-12-31.
-        The transition must not introduce a ~86400s jump.
-        """
-        df = pd.DataFrame({
-            "Test Time / s": [
-                "23:59:58",                     # 86398s
-                "23:59:59",                     # 86399s
-                "1900-01-01 00:00:00.000000",   # 24h exactly = 86400s
-                "1900-01-01 00:00:01.000000",   # 86401s
-            ],
-            "Voltage / V": [3.7, 3.8, 3.9, 4.0],
-        })
-        result = self.plugin.fixup(df)
-        seconds = result["Test Time / s"]
-        assert seconds.dtype == np.float64
-        assert seconds.iloc[0] == 86398.0
-        assert seconds.iloc[1] == 86399.0
-        assert seconds.iloc[2] == 86400.0
-        assert seconds.iloc[3] == 86401.0
-        # Verify no jump > 2s between consecutive rows
+        result = self.plugin.parse(p)
+        seconds = result["Total Time"]
+        assert np.isclose(seconds.iloc[0], 86398.0)
+        assert np.isclose(seconds.iloc[1], 86399.0)
+        assert np.isclose(seconds.iloc[2], 86400.0)
+        assert np.isclose(seconds.iloc[3], 86401.0)
         diffs = seconds.diff().dropna()
         assert (diffs <= 2.0).all(), f"Discontinuity at 24h boundary: {diffs.tolist()}"
-
-    def test_skips_missing_time_columns(self):
-        df = pd.DataFrame({"Voltage / V": [3.7, 3.8]})
-        result = self.plugin.fixup(df)
-        assert "Test Time / s" not in result.columns
-
 
 # Full pipeline: parse → augment → normalize → fixup
 
@@ -312,7 +285,9 @@ class TestFullPipeline:
         assert "Unix Time / s" in out.columns
         assert out["Unix Time / s"].dtype == np.float64
         # Verify values are plausible epoch seconds (year 2026 ≈ 1.77e9)
-        assert out["Unix Time / s"].iloc[0] > 1.7e9
+        assert pytest.approx(out["Unix Time / s"].iloc[0], abs=1e-6) == 1773056138
+        assert pytest.approx(out["Unix Time / s"].iloc[1], abs=1e-6) == 1773056139
+
 
     def test_current_ma_scaled_to_amps(self, tmp_path):
         """Current(mA) header should be converted to Amps."""
@@ -354,16 +329,19 @@ class TestFullPipeline:
 
 class TestFindRecordSheet:
     def test_finds_record_sheet(self, tmp_path):
+        """Finds the record sheet when present."""
         p = tmp_path / "test.xlsx"
         pd.DataFrame({"A": [1]}).to_excel(p, sheet_name="record", index=False)
         assert NewareXlsx._find_record_sheet(p) == "record"
 
     def test_returns_none_without_record_sheet(self, tmp_path):
+        """Returns None when no record sheet exists."""
         p = tmp_path / "test.xlsx"
         pd.DataFrame({"A": [1]}).to_excel(p, sheet_name="data", index=False)
         assert NewareXlsx._find_record_sheet(p) is None
 
     def test_returns_none_for_invalid_file(self, tmp_path):
+        """Returns None for unreadable Excel files."""
         p = tmp_path / "bad.xlsx"
         p.write_bytes(b"not an excel file")
         assert NewareXlsx._find_record_sheet(p) is None

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,0 +1,96 @@
+import pandas as pd
+
+from bdf.normalize.normalize import _enforce_normalized_dtypes, _is_hms_duration_series
+
+
+def test_is_hms_duration_series_true_for_hms_values():
+    """Returns True for HH:MM:SS(.f) string values."""
+    s = pd.Series(["00:00:10", "12:34:56.789", None])
+
+    assert _is_hms_duration_series(s)
+
+
+def test_is_hms_duration_series_false_for_numeric_strings():
+    """Returns False for plain numeric strings."""
+    s = pd.Series(["1.0", "2.5", None])
+
+    assert not _is_hms_duration_series(s)
+
+
+def test_is_hms_duration_series_true_for_timedelta_dtype():
+    """Returns True for timedelta-typed series."""
+    s = pd.Series([pd.Timedelta(seconds=10), pd.Timedelta(seconds=20.5)])
+
+    assert _is_hms_duration_series(s)
+
+
+def test_is_hms_duration_series_false_for_datetime_dtype():
+    """Returns False for datetime-typed series."""
+    s = pd.to_datetime(pd.Series(["2026-01-01T00:00:10Z", "2026-01-01T00:00:20Z"]))
+
+    assert not _is_hms_duration_series(s)
+
+
+def test_enforce_normalized_dtypes_time_column_numeric_strings_are_seconds():
+    """Parses numeric-string time values as seconds."""
+    df = pd.DataFrame(
+        {
+            "Test Time / s": ["1.0", "2.5"],
+            "Voltage / V": ["3.50", "3.60"],
+            "Current / A": ["0.10", "0.20"],
+        }
+    )
+
+    out = _enforce_normalized_dtypes(df)
+
+    assert out["Test Time / s"].tolist() == [1.0, 2.5]
+
+
+def test_enforce_normalized_dtypes_time_column_hms_is_duration_seconds():
+    """Parses HH:MM:SS(.f) time values into seconds."""
+    df = pd.DataFrame(
+        {
+            "Test Time / s": ["00:00:10", "00:01:02.5"],
+            "Voltage / V": ["3.50", "3.60"],
+            "Current / A": ["0.10", "0.20"],
+        }
+    )
+
+    out = _enforce_normalized_dtypes(df)
+
+    assert out["Test Time / s"].tolist() == [10.0, 62.5]
+
+
+def test_enforce_normalized_dtypes_time_column_timedelta_is_seconds():
+    """Converts timedelta time values to numeric seconds."""
+    df = pd.DataFrame(
+        {
+            "Test Time / s": [pd.Timedelta(seconds=10), pd.Timedelta(seconds=62.5)],
+            "Voltage / V": ["3.50", "3.60"],
+            "Current / A": ["0.10", "0.20"],
+        }
+    )
+
+    out = _enforce_normalized_dtypes(df)
+
+    assert out["Test Time / s"].tolist() == [10.0, 62.5]
+
+
+def test_enforce_normalized_dtypes_preserves_numeric_time_and_parses_numeric_strings():
+    """Preserves numeric time columns and coerces other numeric strings."""
+    df = pd.DataFrame(
+        {
+            "Test Time / s": [1.0, 2.0],
+            "Step Time / s": [0.5, 1.5],
+            "Voltage / V": ["3.50", "3.60"],
+            "Cycle Number / 1": ["1", "2"],
+        }
+    )
+
+    out = _enforce_normalized_dtypes(df)
+
+    assert out["Test Time / s"].tolist() == [1.0, 2.0]
+    assert out["Step Time / s"].tolist() == [0.5, 1.5]
+    assert out["Voltage / V"].tolist() == [3.5, 3.6]
+    assert out["Cycle Number / 1"].tolist() == [1, 2]
+    assert str(out["Cycle Number / 1"].dtype) == "Int64"

--- a/tests/unit/test_timezone.py
+++ b/tests/unit/test_timezone.py
@@ -1,0 +1,232 @@
+from bdf.data_sources.base_delimited import DelimitedTextPlugin
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import bdf
+
+
+def test_timezone_parameter_applied_to_plugin(tmp_path, monkeypatch):
+    """Verify that timezone parameter is applied to plugin before parse()."""
+    raw = tmp_path / "raw.dat"
+    raw.write_text("dummy")
+
+    captured_timezone = None
+
+    class MockPlugin:
+        id = "mock"
+        assume_naive_tz = "UTC"
+        column_synonyms = {
+            "Test Time / s": ["time"],
+            "Voltage / V": ["voltage"],
+            "Current / A": ["current"],
+        }
+
+        def parse(self, path: Path):
+            nonlocal captured_timezone
+            captured_timezone = self.assume_naive_tz
+            return pd.DataFrame(
+                {
+                    "time": [0, 1],
+                    "voltage": [3.7, 3.6],
+                    "current": [0.1, 0.1],
+                }
+            )
+
+        def augment(self, df_raw: pd.DataFrame):
+            return df_raw
+
+        def fixup(self, df: pd.DataFrame):
+            return df
+
+    monkeypatch.setattr(
+        bdf,
+        "_candidate_plugins",
+        lambda path, *, plugin, plugin_hint: [MockPlugin()],
+    )
+
+    # Test with timezone parameter
+    bdf.read(raw, timezone="America/New_York", validate=True)
+    assert captured_timezone == "America/New_York"
+
+    # Test without timezone parameter (should remain default)
+    bdf.read(raw, validate=True)
+    assert captured_timezone == "UTC"
+
+
+def test_timezone_parameter_with_naive_timestamp_column(tmp_path, monkeypatch):
+    """Verify timezone affects parsing of naive timestamp columns."""
+    raw = tmp_path / "raw.dat"
+    raw.write_text("dummy")
+
+    class TimestampPlugin:
+        id = "timestamp-plugin"
+        assume_naive_tz = "UTC"
+        timestamp_candidate_patterns = ("Date Time",)
+        column_synonyms = {
+            "Test Time / s": ["test time (s)"],
+            "Voltage / V": ["voltage (v)"],
+            "Current / A": ["current (a)"],
+        }
+
+        def parse(self, path: Path):
+            # A naive datetime (no timezone info)
+            return pd.DataFrame(
+                {
+                    "Date Time": pd.to_datetime(
+                        ["2024-01-15 12:00:00", "2024-01-15 12:00:01"]
+                    ),
+                    "test time (s)": [0, 1],
+                    "voltage (v)": [3.7, 3.6],
+                    "current (a)": [0.1, 0.1],
+                }
+            )
+
+        def augment(self, df_raw: pd.DataFrame):
+            # _ensure_unix_time will convert naive "Date Time" using self.assume_naive_tz
+            from bdf.time import parse_unix_time
+
+            if "Unix Time / s" not in df_raw.columns:
+                unix = parse_unix_time(
+                    df_raw["Date Time"],
+                    fmt=None,
+                    tz=self.assume_naive_tz,
+                    min_success=0.5,
+                )
+                df_raw = df_raw.copy()
+                df_raw["Unix Time / s"] = unix
+            return df_raw
+
+        def fixup(self, df: pd.DataFrame):
+            return df
+
+    monkeypatch.setattr(
+        bdf,
+        "_candidate_plugins",
+        lambda path, *, plugin, plugin_hint: [TimestampPlugin()],
+    )
+
+    # Read with UTC (default behavior)
+    df_utc = bdf.read(raw, timezone="UTC", validate=False)
+    utc_epoch = df_utc["Unix Time / s"].iloc[0]
+
+    # Read with no timezone (should default to plugin's assume_naive_tz, which is UTC)
+    df_none = bdf.read(raw, timezone=None, validate=False)
+    none_epoch = df_none["Unix Time / s"].iloc[0]
+    assert none_epoch == utc_epoch
+
+    # Read with America/New_York (UTC-5 in winter, UTC-4 in summer)
+    df_ny = bdf.read(raw, timezone="America/New_York", validate=False)
+    ny_epoch = df_ny["Unix Time / s"].iloc[0]
+
+    # Same wall-clock time (2024-01-15 12:00:00) interpreted as NY is 5 hours later in UTC
+    # than when interpreted as UTC, so NY epoch should be 5 hours greater
+    assert ny_epoch - utc_epoch == pytest.approx(5 * 3600, abs=1)
+
+
+def test_timezone_parameter_with_parse_function(tmp_path, monkeypatch):
+    """Verify timezone parameter works with parse() convenience function."""
+    raw = tmp_path / "raw.dat"
+    raw.write_text("dummy")
+
+    captured_timezone = None
+
+    class MockPlugin:
+        id = "mock"
+        assume_naive_tz = "UTC"
+        column_synonyms = {
+            "Test Time / s": ["time"],
+            "Voltage / V": ["voltage"],
+            "Current / A": ["current"],
+        }
+
+        def parse(self, path: Path):
+            nonlocal captured_timezone
+            captured_timezone = self.assume_naive_tz
+            return pd.DataFrame(
+                {
+                    "time": [0, 1],
+                    "voltage": [3.7, 3.6],
+                    "current": [0.1, 0.1],
+                }
+            )
+
+        def augment(self, df_raw: pd.DataFrame):
+            return df_raw
+
+        def fixup(self, df: pd.DataFrame):
+            return df
+
+    monkeypatch.setattr(
+        bdf,
+        "_candidate_plugins",
+        lambda path, *, plugin, plugin_hint: [MockPlugin()],
+    )
+
+    # parse() should also accept and pass through timezone parameter
+    bdf.parse(raw, timezone="Europe/London")
+    assert captured_timezone == "Europe/London"
+
+
+def test_timezone_parameter_unix_time_conversion_real_data(tmp_path, monkeypatch):
+    """
+    Verify Unix Time column is correctly converted when reading vendor data 
+    with different timezone parameters.
+    
+    Generates a DataFrame with naive datetime, writes to CSV, then reads back
+    with different timezone parameters. The plugin's timestamp_candidate_patterns
+    identifies the timestamp column, and BDF's normalization logic automatically
+    converts it to Unix Time using the timezone parameter. Confirms Unix Time 
+    differs correctly based on timezone interpretation.
+    """
+    # Create a CSV file with naive timestamp strings (use vendor-style column names
+    # to avoid being detected as BDF artifact)
+    csv_file = tmp_path / "test_data.csv"
+    csv_content = """time (s),voltage (v),current (a),timestamp
+0.0,3.707,0.0,2024-01-15 12:00:00
+1.0,3.706,0.0,2024-01-15 12:00:01
+2.0,3.705,0.0,2024-01-15 12:00:02
+"""
+    csv_file.write_text(csv_content)
+
+    class TimestampParsingPlugin(DelimitedTextPlugin):
+        """Mock plugin that identifies timestamps for BDF normalization to handle."""
+        id = "timestamp-test"
+        assume_naive_tz = "UTC"
+        timestamp_candidate_patterns = ("timestamp",)
+        timestamp_formats = ("%Y-%m-%d %H:%M:%S",)
+        column_synonyms = {
+            "Test Time / s": ["time (s)"],
+            "Voltage / V": ["voltage (v)"],
+            "Current / A": ["current (a)"],
+        }
+
+        def parse(self, path: Path):
+            # Parse CSV; leave timestamp as string for BDF to detect and convert
+            return pd.read_csv(path)
+
+
+    monkeypatch.setattr(
+        bdf,
+        "_candidate_plugins",
+        lambda path, *, plugin, plugin_hint: [TimestampParsingPlugin()],
+    )
+
+    # Read with UTC timezone
+    df_utc = bdf.read(csv_file, timezone="UTC", validate=False)
+    assert "Unix Time / s" in df_utc.columns
+    utc_times = df_utc["Unix Time / s"].values
+    
+    # Read with America/New_York timezone (UTC-5 in winter, Jan-15)
+    df_ny = bdf.read(csv_file, timezone="America/New_York", validate=False)
+    assert "Unix Time / s" in df_ny.columns
+    ny_times = df_ny["Unix Time / s"].values
+    
+    # Same wall-clock time "2024-01-15 12:00:00" interpreted as NY time
+    # is 5 hours behind UTC, so NY epoch should be 5 hours GREATER
+    expected_diff = 5 * 3600
+    
+    # Check that Unix Time differs by approximately 5 hours between timezones
+    actual_diffs = ny_times - utc_times
+    assert actual_diffs == pytest.approx(expected_diff, abs=1)


### PR DESCRIPTION
This PR updates and adds cycler plugins so that bdf.read() behaviour matches expected behaviour on test cases used in the PyProBE package, allowing PyProBE to transition to use bdf data ingestion.

**New Data Source Plugins:**

* Added `ArbinCSV` plugin to support Arbin CSV exports, with explicit handling for headers, units, and time columns.
* Added `MaccorCSV` plugin to support Maccor CSV exports, including extraction of start time from header and correct mapping of capacity/energy columns.

**Start Time Extraction and Time Handling:**

* Introduced generic start time extraction in `DelimitedTextPlugin`, allowing plugins to define regex and format for parsing start timestamps from file headers. The extracted start time is used to compute absolute Unix time columns when missing. [[1]](diffhunk://#diff-1329a299fa9d022587e7019f35025da39c1dd53a7630d0f855920a6bdd1382e6R45-R48) [[2]](diffhunk://#diff-1329a299fa9d022587e7019f35025da39c1dd53a7630d0f855920a6bdd1382e6R102) [[3]](diffhunk://#diff-1329a299fa9d022587e7019f35025da39c1dd53a7630d0f855920a6bdd1382e6R124-R139) [[4]](diffhunk://#diff-1329a299fa9d022587e7019f35025da39c1dd53a7630d0f855920a6bdd1382e6L459-R497) [[5]](diffhunk://#diff-689ceac48d11d0d0b15b395baa3db748824020d6e6a70d6b11f87afa76c7db73R56-R58) [[6]](diffhunk://#diff-9e2b9af71c4706ad94e5e1dabfca70bcac0be0adaad9c8d4b2498fe5c5ccf141R18-R21)
* `CyclerPlugin` now supports specifying a timestamp format for direct parsing of timestamp columns, improving robustness for various datetime representations. [[1]](diffhunk://#diff-7807835bcf3d4779e809b47fd15def6d10e952a130c1d893d4ba7aff52dd495dR65-R66) [[2]](diffhunk://#diff-7807835bcf3d4779e809b47fd15def6d10e952a130c1d893d4ba7aff52dd495dL124-R126)

**Improvements to Existing Plugins:**

* **NewareCSV**:
    - Enhanced synonym and unit detection for time, capacity, and temperature columns, including support for step/test time in "hms" format and additional surface temperature channels. [[1]](diffhunk://#diff-7b66b73016d3602b2676992a1d0dfec6bd28f9b88d260b31a96a21b68d365351R13-R15) [[2]](diffhunk://#diff-7b66b73016d3602b2676992a1d0dfec6bd28f9b88d260b31a96a21b68d365351L21-R25) [[3]](diffhunk://#diff-7b66b73016d3602b2676992a1d0dfec6bd28f9b88d260b31a96a21b68d365351L33-R38) [[4]](diffhunk://#diff-7b66b73016d3602b2676992a1d0dfec6bd28f9b88d260b31a96a21b68d365351L43-R48) [[5]](diffhunk://#diff-7b66b73016d3602b2676992a1d0dfec6bd28f9b88d260b31a96a21b68d365351L53-R69) [[6]](diffhunk://#diff-7b66b73016d3602b2676992a1d0dfec6bd28f9b88d260b31a96a21b68d365351R80) [[7]](diffhunk://#diff-7b66b73016d3602b2676992a1d0dfec6bd28f9b88d260b31a96a21b68d365351R90) [[8]](diffhunk://#diff-7b66b73016d3602b2676992a1d0dfec6bd28f9b88d260b31a96a21b68d365351L92-R105)
* **BioLogicMPT**:
    - Added start time extraction from header and new synonyms/units for step index. [[1]](diffhunk://#diff-9e2b9af71c4706ad94e5e1dabfca70bcac0be0adaad9c8d4b2498fe5c5ccf141R18-R21) [[2]](diffhunk://#diff-9e2b9af71c4706ad94e5e1dabfca70bcac0be0adaad9c8d4b2498fe5c5ccf141R34) [[3]](diffhunk://#diff-9e2b9af71c4706ad94e5e1dabfca70bcac0be0adaad9c8d4b2498fe5c5ccf141R83-R85)
* **BasytecTxt**:
    - Added start time extraction from header and support for net capacity and step index columns. [[1]](diffhunk://#diff-689ceac48d11d0d0b15b395baa3db748824020d6e6a70d6b11f87afa76c7db73R29-R39) [[2]](diffhunk://#diff-689ceac48d11d0d0b15b395baa3db748824020d6e6a70d6b11f87afa76c7db73R56-R58)

**General Robustness and Extensibility:**

* `DelimitedTextPlugin._looks_ok` now uses `header_token_patterns` instead of hardcoded column names that were specific to BioLogic and Basytec cyclers