### PR TITLE
fix: resolve three CI test failures on main

### DIFF
--- a/src/bdf/__init__.py
+++ b/src/bdf/__init__.py
@@ -1926,7 +1926,7 @@ def ingest(
 
         cell_root = _cell_meta_root()
         for battery in batteries:
-            cell_id = str(battery.id)
+            cell_id = str(battery.id).lower()
             cell_dir = cell_root / cell_id
             cell_dir.mkdir(parents=True, exist_ok=True)
             meta_out = cell_dir / "metadata.jsonld"

--- a/src/bdf/time.py
+++ b/src/bdf/time.py
@@ -69,11 +69,8 @@ def _datetime_to_unix(dt: pd.Series, *, min_success: float) -> pd.Series:
 
     valid = dt.notna().to_numpy()
     epoch_s = np.full(len(dt), np.nan, dtype="float64")
-    try:
-        epoch_ns_valid = dt.astype("int64")[valid]
-    except TypeError:
-        epoch_ns_valid = dt.view("int64")[valid]
-    epoch_s[valid] = epoch_ns_valid.astype("float64") / 1_000_000_000.0
+    epoch = dt - pd.Timestamp("1970-01-01", tz="UTC")
+    epoch_s[valid] = epoch.dt.total_seconds().to_numpy(dtype="float64")[valid]
     return pd.Series(epoch_s, index=dt.index, name="Unix Time / s")
 
 

--- a/tests/unit/test_ontology_labels.py
+++ b/tests/unit/test_ontology_labels.py
@@ -8,13 +8,23 @@ import pytest
 import bdf
 
 
-def test_legacy_labels_normalized_from_ontology(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_legacy_labels_normalized_from_ontology(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     ontology = Path("tests/fixtures/ontology_labels.ttl").resolve()
     monkeypatch.setenv("BDF_ONTOLOGY_PATH", str(ontology))
 
-    legacy_path = Path("data/empa__ccid000001.bdf.parquet")
-    df = pd.read_parquet(legacy_path)
-    assert "test_time_millisecond" in df.columns
+    df = pd.DataFrame(
+        {
+            "test_time_millisecond": [0.0, 1000.0],
+            "voltage_volt": [3.7, 3.8],
+            "current_ampere": [0.1, 0.1],
+            "cycle_count": [1, 1],
+            "ambient_temperature_celsius": [25.0, 25.0],
+        }
+    )
+    legacy_path = tmp_path / "legacy.bdf.parquet"
+    df.to_parquet(legacy_path, index=False)
 
     with pytest.warns(UserWarning):
         normalized = bdf.read(legacy_path, validate=True)


### PR DESCRIPTION
## Summary
- **time**: use `total_seconds()` instead of `int64` cast for pandas 2.x compatibility (1000x scaling error)
- **ingest**: lowercase `cell_id` when creating nested metadata directories
- **tests**: generate legacy parquet fixture inline instead of referencing missing file

## Test plan
- [x] All 37 unit tests pass locally
- [x] CI passes on this branch