### PR TITLE
Extract file extension from URL path during caching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
   "pydantic>=2.6",
   "requests>=2.31",
   "pint>=0.22",
-  "NewareNDA"
+  "NewareNDA",
+  "platformdirs>=4.10.0",
 ]
 
 [project.urls]

--- a/src/bdf/fetch.py
+++ b/src/bdf/fetch.py
@@ -6,6 +6,7 @@ import json
 import os
 import tempfile
 import time
+import warnings
 
 # mypy: ignore-errors
 from collections.abc import Iterable
@@ -20,6 +21,7 @@ from platformdirs import user_cache_dir
 # Utilities
 # -------------------------------
 
+
 def sha256_file(path: Path) -> str:
     h = hashlib.sha256()
     with open(path, "rb") as f:
@@ -27,18 +29,43 @@ def sha256_file(path: Path) -> str:
             h.update(chunk)
     return h.hexdigest()
 
+
 def _cache_dir(subdir: str = "bdf") -> Path:
     p = Path(user_cache_dir(subdir))
     p.mkdir(parents=True, exist_ok=True)
     return p
 
 def _safe_cache_name(url: str, filename: Optional[str]) -> str:
+    """Ensure uniqueness across different URLs that share the same basename.
+
+    Walks URL path segments right-to-left to find a meaningful filename with
+    extension (handles URLs like `.../file.csv/content`). Issues a warning
+    if no extension is found and ``filename`` is not provided.
     """
-    Ensure uniqueness across different URLs that share the same basename.
-    """
-    base = (filename or Path(url.split("?", 1)[0]).name) or "file"
+    if filename:
+        base = filename
+    else:
+        from urllib.parse import urlparse
+
+        url_path = urlparse(url).path
+        segments = [s for s in url_path.split("/") if s]
+        base = None
+        for segment in reversed(segments):
+            if Path(segment).suffix:
+                base = segment
+                break
+        if base is None:
+            warnings.warn(
+                f"Cannot determine file type from URL {url!r}. "
+                "Provide the filename= parameter to fetch_url for better caching, "
+                "or specify a plugin explicitly.",
+                UserWarning,
+                stacklevel=3,
+            )
+            base = "file"
     h = hashlib.sha256(url.encode("utf-8")).hexdigest()[:12]
     return f"{h}__{base}"
+
 
 def _download(url: str, dest: Path, timeout: int = 120) -> None:
     with requests.get(url, stream=True, timeout=timeout) as r:
@@ -49,6 +76,7 @@ def _download(url: str, dest: Path, timeout: int = 120) -> None:
                     tmp.write(chunk)
             tmp_path = Path(tmp.name)
     tmp_path.replace(dest)
+
 
 def fetch_url(
     url: str,
@@ -109,9 +137,11 @@ def fetch_url(
         raise last_err
     raise RuntimeError("Download failed for unknown reasons.")
 
+
 # -------------------------------
 # Registry loading (accepts either {"datasets":[...]} or {"entries":[...]})
 # -------------------------------
+
 
 def _find_repo_root(markers=("pyproject.toml", ".git"), max_up: int = 8) -> Path:
     p = Path.cwd().resolve()
@@ -120,6 +150,7 @@ def _find_repo_root(markers=("pyproject.toml", ".git"), max_up: int = 8) -> Path
             return p
         p = p.parent
     return Path.cwd().resolve()
+
 
 def load_registry(path: Optional[Union[str, Path]] = None) -> Dict[str, Any]:
     """
@@ -156,9 +187,11 @@ def load_registry(path: Optional[Union[str, Path]] = None) -> Dict[str, Any]:
 
     raise FileNotFoundError("datasets.json not found. Provide path or set BDF_DATASETS.")
 
+
 # -------------------------------
 # Model & helpers
 # -------------------------------
+
 
 @dataclass
 class DatasetEntry:
@@ -180,11 +213,14 @@ class DatasetEntry:
     alt_urls: List[str] = field(default_factory=list)
     notes: Optional[str] = None
 
+
 def _ci_eq(a: Optional[str], b: Optional[str]) -> bool:
     return (a or "").lower() == (b or "").lower()
 
+
 def _set_ci(elems: Iterable[str]) -> set:
     return {str(x).lower() for x in elems}
+
 
 def _iter_dataset_dicts(reg: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
     """Yield each dataset dict from the registry."""
@@ -200,6 +236,7 @@ def _iter_dataset_dicts(reg: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
         for d in reg:
             if isinstance(d, dict):
                 yield d
+
 
 def _coerce_entry(d: Dict[str, Any]) -> DatasetEntry:
     return DatasetEntry(
@@ -219,6 +256,7 @@ def _coerce_entry(d: Dict[str, Any]) -> DatasetEntry:
         notes=d.get("notes"),
     )
 
+
 def list_registry_entries(reg: Dict[str, Any]) -> List[Tuple[str, str, str, str, str]]:
     """
     Flatten into rows:
@@ -233,6 +271,7 @@ def list_registry_entries(reg: Dict[str, Any]) -> List[Tuple[str, str, str, str,
         nm = str(d.get("name") or "")
         rows.append((eid, vendor, fmt, tags, nm))
     return rows
+
 
 def find_datasets(
     reg: Dict[str, Any],
@@ -266,6 +305,7 @@ def find_datasets(
         out.append(_coerce_entry(d))
     return out
 
+
 def get_entry(
     reg: Dict[str, Any],
     *args: str,
@@ -296,13 +336,16 @@ def get_entry(
     if not matches:
         raise ValueError("No dataset matched filters.")
     if len(matches) > 1:
-        raise ValueError(f"Multiple datasets matched; please refine filters. "
-                         f"First few ids: {[m.id for m in matches[:5]]}")
+        raise ValueError(
+            f"Multiple datasets matched; please refine filters. First few ids: {[m.id for m in matches[:5]]}"
+        )
     return matches[0]
+
 
 # -------------------------------
 # High-level loader (NEW API)
 # -------------------------------
+
 
 def load_bdf_from_entry(entry: DatasetEntry):
     """
@@ -312,6 +355,7 @@ def load_bdf_from_entry(entry: DatasetEntry):
     Returns (local_path, df_bdf).
     """
     from . import read as read_bdf  # new API
+
     path = fetch_url(
         entry.url,
         sha256=entry.sha256,
@@ -321,6 +365,7 @@ def load_bdf_from_entry(entry: DatasetEntry):
 
     if entry.is_bdf:
         from .io import load as load_bdf  # lazy import to avoid cycles
+
         df = load_bdf(path)
     else:
         df = read_bdf(path, plugin=entry.plugin, validate=True)

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -1,0 +1,51 @@
+"""Unit tests for bdf.fetch utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from bdf.fetch import _safe_cache_name
+
+
+class TestSafeCacheName:
+    """Tests for _safe_cache_name."""
+
+    def test_explicit_filename_used_as_is(self) -> None:
+        name = _safe_cache_name("https://example.com/data", "myfile.csv")
+        assert name.endswith("__myfile.csv")
+
+    def test_explicit_filename_overrides_url_ext(self) -> None:
+        name = _safe_cache_name("https://example.com/data.nda/content", "override.csv")
+        assert name.endswith("__override.csv")
+
+    def test_extension_from_last_url_segment(self) -> None:
+        name = _safe_cache_name("https://example.com/path/data.csv", None)
+        assert name.endswith("__data.csv")
+
+    def test_extension_found_by_walking_right_to_left(self) -> None:
+        # Zenodo-style: real filename buried, then /content appended
+        name = _safe_cache_name(
+            "https://zenodo.org/api/records/123/files/SINTEF__Neware.nda/content",
+            None,
+        )
+        assert name.endswith("__SINTEF__Neware.nda")
+
+    def test_query_string_stripped_before_walking(self) -> None:
+        name = _safe_cache_name("https://example.com/files/data.csv/download?token=abc", None)
+        assert name.endswith("__data.csv")
+
+    def test_hash_prefix_ensures_uniqueness(self) -> None:
+        name_a = _safe_cache_name("https://host-a.com/data.csv", None)
+        name_b = _safe_cache_name("https://host-b.com/data.csv", None)
+        assert name_a != name_b
+        assert name_a.endswith("__data.csv")
+        assert name_b.endswith("__data.csv")
+
+    def test_no_extension_anywhere_warns(self) -> None:
+        with pytest.warns(UserWarning, match="Cannot determine file type"):
+            name = _safe_cache_name("https://example.com/api/data", None)
+        assert name.endswith("__file")
+
+    def test_no_extension_warning_message_mentions_filename_param(self) -> None:
+        with pytest.warns(UserWarning, match="filename="):
+            _safe_cache_name("https://example.com/api/v1/resource", None)


### PR DESCRIPTION
## Summary

Improves file caching by extracting file extensions from URLs more reliably. Walks URL path segments right-to-left to find filenames with extensions, handling cases where filenames are buried before `/content` or other path suffixes (e.g., Zenodo API URLs). Adds `platformdirs` dependency for cache directory resolution.

## Features

- Enhanced `_safe_cache_name()` to extract file extensions by walking URL path segments right-to-left, with fallback to filename parameter ([bc0761d](https://github.com/tomjholland/battery-data-format/commit/bc0761d))
  - Issues warning if no extension found and filename not provided

## Dependencies

- Add `platformdirs` dependency for resolving user-scoped cache directories ([24f830e](https://github.com/tomjholland/battery-data-format/commit/24f830e))

## Tests

- Comprehensive test coverage for `_safe_cache_name()` including:
  - Explicit filename override
  - Extension extraction from last segment
  - Right-to-left walking for buried filenames (Zenodo-style URLs)
  - Query string stripping
  - Hash prefix uniqueness for same-basename URLs
  - Warning behavior for missing extensions