### PR TITLE
fix: regenerate bundled ontology snapshot with step-directional terms

### DIFF
--- a/src/bdf/data/bdf-ontology-snapshot.ttl
+++ b/src/bdf/data/bdf-ontology-snapshot.ttl
@@ -18,9 +18,13 @@ dcterms:bibliographicCitation a owl:AnnotationProperty .
 
 dcterms:created a owl:AnnotationProperty .
 
+dcterms:isReplacedBy a owl:AnnotationProperty .
+
 dcterms:issued a owl:AnnotationProperty .
 
 dcterms:modified a owl:AnnotationProperty .
+
+dcterms:replaces a owl:AnnotationProperty .
 
 bibo:doi a owl:AnnotationProperty .
 
@@ -34,9 +38,13 @@ skos:definition a owl:AnnotationProperty .
 
 skos:exactMatch a owl:AnnotationProperty .
 
+skos:historyNote a owl:AnnotationProperty .
+
 skos:notation a owl:AnnotationProperty .
 
 prov:wasDerivedFrom a owl:AnnotationProperty .
+
+prov:wasRevisionOf a owl:AnnotationProperty .
 
 schema:description a owl:AnnotationProperty .
 
@@ -53,7 +61,7 @@ schema:unitText a owl:AnnotationProperty .
     dcterms:creator <https://orcid.org/0000-0002-8758-6109> ;
     dcterms:issued "2026-05-14"^^xsd:date ;
     dcterms:license <http://www.apache.org/licenses/LICENSE-2.0> ;
-    dcterms:modified "2026-05-14"^^xsd:date ;
+    dcterms:modified "2026-06-08"^^xsd:date ;
     dcterms:publisher "Battery Data Alliance" ;
     dcterms:title "Battery Data Format Ontology"@en ;
     bibo:doi "pending" ;
@@ -61,9 +69,9 @@ schema:unitText a owl:AnnotationProperty .
     vann:preferredNamespacePrefix "bdf" ;
     vann:preferredNamespaceUri "https://w3id.org/battery-data-alliance/ontology/battery-data-format#" ;
     owl:imports <https://w3id.org/emmo/domain/battery/0.18.6/battery> ;
-    owl:priorVersion <https://w3id.org/battery-data-alliance/ontology/battery-data-format/0.1.0-beta/battery-data-format> ;
-    owl:versionIRI <https://w3id.org/battery-data-alliance/ontology/battery-data-format/1.0.0/battery-data-format> ;
-    owl:versionInfo "1.0.0" .
+    owl:priorVersion <https://w3id.org/battery-data-alliance/ontology/battery-data-format/1.0.0/battery-data-format> ;
+    owl:versionIRI <https://w3id.org/battery-data-alliance/ontology/battery-data-format/1.1.0/battery-data-format> ;
+    owl:versionInfo "1.1.0" .
 
 :absolute_impedance_ohm a owl:Class ;
     rdfs:label "Absolute Impedance / ohm"@en ;
@@ -78,7 +86,10 @@ schema:unitText a owl:AnnotationProperty .
     prov:wasDerivedFrom :imaginary_impedance_ohm,
         :real_impedance_ohm ;
     schema:unitCode "Ohm" ;
-    schema:unitText "ohm"@en .
+    schema:unitText "ohm"@en ;
+    :latexFormula "|Z| = \\sqrt{Z_\\mathrm{re}^2 + Z_\\mathrm{im}^2}"^^xsd:string ;
+    :latexSymbol "|Z|"^^xsd:string ;
+    :obligation "optional" .
 
 :ambient_pressure_pa a owl:Class ;
     rdfs:label "Ambient Pressure / Pa"@en ;
@@ -99,6 +110,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Ambient Pressure / Pa"@en ;
     schema:unitCode "Pa" ;
     schema:unitText "pascal"@en ;
+    :latexSymbol "p_\\mathrm{amb}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Ambient air pressure recorded during testing, in pascal."@en .
 
 :ambient_temperature_celsius a owl:Class ;
@@ -120,6 +133,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Ambient Temperature / degC"@en ;
     schema:unitCode "Cel" ;
     schema:unitText "degree Celsius"@en ;
+    :latexSymbol "T_\\mathrm{amb}"^^xsd:string ;
+    :obligation "recommended" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Ambient temperature recorded during testing, in degree Celsius."@en .
 
 :applied_pressure_pa a owl:Class ;
@@ -141,6 +156,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Applied Pressure / Pa"@en ;
     schema:unitCode "Pa" ;
     schema:unitText "pascal"@en ;
+    :latexSymbol "p_\\mathrm{app}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "External pressure applied to the test object, in pascal."@en .
 
 :cumulative_capacity_ah a owl:Class ;
@@ -165,6 +182,9 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Cumulative Capacity / Ah"@en ;
     schema:unitCode "A.h" ;
     schema:unitText "ampere hour"@en ;
+    :latexFormula "Q_\\mathrm{cum}(t) = Q_\\mathrm{chg}(t) + Q_\\mathrm{dchg}(t) = \\frac{1}{3600}\\int_0^t \\bigl|I(\\tau)\\bigr|\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "Q_\\mathrm{cum}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Total Ah throughput since the start of the test, in ampere hour. Defined as charging_capacity_ah + discharging_capacity_ah; always monotonically non-decreasing. Counts charge flow in both directions and is therefore independent of the net state of charge. Suitable for throughput-based degradation models."@en .
 
 :cumulative_energy_wh a owl:Class ;
@@ -189,6 +209,9 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Cumulative Energy / Wh"@en ;
     schema:unitCode "W.h" ;
     schema:unitText "watt hour"@en ;
+    :latexFormula "E_\\mathrm{cum}(t) = E_\\mathrm{chg}(t) + E_\\mathrm{dchg}(t) = \\frac{1}{3600}\\int_0^t \\bigl|P(\\tau)\\bigr|\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "E_\\mathrm{cum}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Total Wh throughput since the start of the test, in watt hour. Defined as charging_energy_wh + discharging_energy_wh; always monotonically non-decreasing."@en .
 
 :cycle_count a owl:Class ;
@@ -211,6 +234,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Cycle Count / 1"@en ;
     schema:unitCode "1" ;
     schema:unitText "one"@en ;
+    :latexSymbol "n"^^xsd:string ;
+    :obligation "recommended" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Cycle index used to segregate time-series data into quasi-periodic subsets, typically tracking performance evolution over aging. Must be a non-negative integer and monotonically non-decreasing within a test. No constraint is placed on the starting value: 0, 1, or any other non-negative integer are all valid. The starting value is instrument-defined and must be preserved as reported; converters must not renumber cycles."@en .
 
 :frequency_hertz a owl:Class ;
@@ -224,7 +249,9 @@ schema:unitText a owl:AnnotationProperty .
     skos:notation "frequency_hertz"@en ;
     skos:prefLabel "Frequency / Hz"@en ;
     schema:unitCode "Hz" ;
-    schema:unitText "hertz"@en .
+    schema:unitText "hertz"@en ;
+    :latexSymbol "f"^^xsd:string ;
+    :obligation "optional" .
 
 :internal_resistance_ohm a owl:Class ;
     rdfs:label "Internal Resistance / ohm"@en ;
@@ -245,7 +272,19 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Internal Resistance / ohm"@en ;
     schema:unitCode "Ohm" ;
     schema:unitText "ohm"@en ;
+    :latexSymbol "R_0"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Direct current internal resistance recorded in ohm."@en .
+
+:latexFormula a owl:AnnotationProperty ;
+    rdfs:label "LaTeX formula"@en ;
+    rdfs:comment "Mathematical definition of a derived quantity in LaTeX notation. Backslashes are single (standard LaTeX)."@en ;
+    rdfs:range xsd:string .
+
+:latexSymbol a owl:AnnotationProperty ;
+    rdfs:label "LaTeX symbol"@en ;
+    rdfs:comment "LaTeX notation for the variable name used to represent this quantity in mathematical expressions."@en ;
+    rdfs:range xsd:string .
 
 :net_capacity_ah a owl:Class ;
     rdfs:label "Net Capacity / Ah"@en ;
@@ -269,6 +308,9 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Net Capacity / Ah"@en ;
     schema:unitCode "A.h" ;
     schema:unitText "ampere hour"@en ;
+    :latexFormula "Q_\\mathrm{net}(t) = Q_\\mathrm{chg}(t) - Q_\\mathrm{dchg}(t) = \\frac{1}{3600}\\int_0^t I(\\tau)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "Q_\\mathrm{net}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Running integral of signed current from the start of the test, in ampere hour. Defined as charging_capacity_ah minus discharging_capacity_ah; can be negative if more charge has been extracted than injected since test start. Equivalent to BioLogic Q-Q0. Increases during charge intervals and decreases during discharge intervals."@en .
 
 :net_energy_wh a owl:Class ;
@@ -293,7 +335,15 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Net Energy / Wh"@en ;
     schema:unitCode "W.h" ;
     schema:unitText "watt hour"@en ;
+    :latexFormula "E_\\mathrm{net}(t) = E_\\mathrm{chg}(t) - E_\\mathrm{dchg}(t) = \\frac{1}{3600}\\int_0^t P(\\tau)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "E_\\mathrm{net}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Running net energy from the start of the test, in watt hour. Defined as charging_energy_wh minus discharging_energy_wh; can be negative if more energy has been extracted than delivered since test start. Increases during charge intervals and decreases during discharge intervals."@en .
+
+:obligation a owl:AnnotationProperty ;
+    rdfs:label "obligation"@en ;
+    rdfs:comment "Conformance level of this term within the default BDF profile (required, recommended, or optional). Obligation is profile-scoped; this annotation expresses the default profile only."@en ;
+    rdfs:range xsd:string .
 
 :phase_degree a owl:Class ;
     rdfs:label "Phase / deg"@en ;
@@ -308,7 +358,10 @@ schema:unitText a owl:AnnotationProperty .
     prov:wasDerivedFrom :imaginary_impedance_ohm,
         :real_impedance_ohm ;
     schema:unitCode "deg" ;
-    schema:unitText "degree"@en .
+    schema:unitText "degree"@en ;
+    :latexFormula "\\phi = \\arctan\\!\\left(\\frac{Z_\\mathrm{im}}{Z_\\mathrm{re}}\\right) \\cdot \\frac{180}{\\pi}"^^xsd:string ;
+    :latexSymbol "\\phi"^^xsd:string ;
+    :obligation "optional" .
 
 :record_index a owl:Class ;
     rdfs:label "Record Index / 1"@en ;
@@ -325,32 +378,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Record Index / 1"@en ;
     schema:unitCode "1" ;
     schema:unitText "one"@en ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "an ordinal, dimensionless integer used to order data records in a time-series dataset, incremented by one for each recorded record and carrying no physical or quantitative meaning"@en .
-
-:step_capacity_ah a owl:Class ;
-    rdfs:label "Step Capacity / Ah"@en ;
-    rdfs:comment "Magnitude of electric charge transferred during the current test step, in ampere hour. Always non-negative (≥ 0); resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en,
-        "Magnitude of electric charge transferred during the current test step, in ampere hour. Always non-negative (≥ 0); resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value. Instruments that export this quantity directly are accepted as-is; where it must be computed, it is the time integral of the absolute current over the step duration."@en ;
-    rdfs:seeAlso unit:A-HR ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
-            owl:someValuesFrom emmo:AmpereHour ],
-        sosa:ObservableProperty,
-        electrochemistry:electrochemistry_ae108db7_8765_4329_9908_059277dee586 ;
-    skos:altLabel "step_capacity_ah"@en,
-        "step_capacity_ampere_hour"@en ;
-    skos:definition "Magnitude of electric charge transferred during the current test step, in ampere hour. Always non-negative (≥ 0); resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value. Instruments that export this quantity directly are accepted as-is; where it must be computed, it is the time integral of the absolute current over the step duration."@en ;
-    skos:exactMatch quantitykind:ElectricCharge ;
-    skos:notation "step_capacity_ah" ;
-    skos:prefLabel "Step Capacity / Ah"@en ;
-    prov:wasDerivedFrom :current_ampere,
-        :step_time_second ;
-    schema:description "Magnitude of electric charge transferred during the current test step, in ampere hour. Always non-negative; resets to zero at each step transition."@en ;
-    schema:measurementTechnique "Time integral of the absolute value of current over the duration of the current test step."@en ;
-    schema:name "Step Capacity / Ah"@en ;
-    schema:unitCode "A.h" ;
-    schema:unitText "ampere hour"@en ;
-    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Magnitude of electric charge transferred during the current test step, in ampere hour. Always non-negative (≥ 0); resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en .
 
 :step_count a owl:Class ;
     rdfs:label "Step Count / 1"@en ;
@@ -372,31 +401,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Step Count / 1"@en ;
     schema:unitCode "1" ;
     schema:unitText "one"@en ;
+    :obligation "recommended" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Monotonically increasing sequential counter incremented by one each time a new step begins, for the duration of the test. Unlike Step ID, this counter never resets and never repeats, making it a unique identifier for each step execution across all cycles."@en .
-
-:step_energy_wh a owl:Class ;
-    rdfs:label "Step Energy / Wh"@en ;
-    rdfs:comment "Magnitude of energy transferred during the current test step, in watt hour. Always non-negative (≥ 0); resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en ;
-    rdfs:seeAlso unit:W-HR ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
-            owl:someValuesFrom emmo:WattHour ],
-        sosa:ObservableProperty,
-        electrochemistry:electrochemistry_46376e5d_9627_4514_9881_9e62083625c3 ;
-    skos:altLabel "step_energy_watt_hour"@en,
-        "step_energy_wh"@en ;
-    skos:definition "Magnitude of energy transferred during the current test step, in watt hour. Always non-negative (≥ 0); resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value. Instruments that export this quantity directly are accepted as-is; where it must be computed, it is the time integral of the absolute instantaneous power over the step duration."@en ;
-    skos:exactMatch quantitykind:Energy ;
-    skos:notation "step_energy_wh" ;
-    skos:prefLabel "Step Energy / Wh"@en ;
-    prov:wasDerivedFrom :power_watt,
-        :step_time_second ;
-    schema:description "Magnitude of energy transferred during the current test step, in watt hour. Always non-negative; resets to zero at each step transition."@en ;
-    schema:measurementTechnique "Time integral of the absolute value of instantaneous power over the duration of the current test step."@en ;
-    schema:name "Step Energy / Wh"@en ;
-    schema:unitCode "W.h" ;
-    schema:unitText "watt hour"@en ;
-    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Magnitude of energy transferred during the current test step, in watt hour. Always non-negative (≥ 0); resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en .
 
 :step_id a owl:Class ;
     rdfs:label "Step ID"@en ;
@@ -412,11 +418,12 @@ schema:unitText a owl:AnnotationProperty .
     skos:prefLabel "Step ID"@en ;
     schema:description "The step identifier as defined in the test program or schedule file. Values are instrument-defined and are not required to be contiguous or monotonically increasing; the same step ID may recur in successive cycles. Known equivalents: Arbin Step_Index, Neware Step_ID, Digatron Step, BioLogic Ns."@en ;
     schema:name "Step ID"@en ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The step identifier as defined in the test program or schedule file. Values are instrument-defined and are not required to be contiguous or monotonically increasing; the same step ID may recur in successive cycles. Known equivalents: Arbin Step_Index, Neware Step_ID, Digatron Step, BioLogic Ns."@en .
 
 :step_index a owl:Class ;
     rdfs:label "Step Index / 1"@en ;
-    rdfs:comment "1-based positional counter for data points within a step. Resets to 1 at the start of each new step and increments by 1 for each subsequent recorded data point. Always derivable from the data; not typically exported directly by cycler software."@en ;
+    rdfs:comment "1-based positional counter for data points within a step. Resets to 1 at the start of each new step and increments by 1 for each subsequent recorded data point. Always derivable from the data; not typically exported directly by cycler software. This is the within-step data-point counter, not the program step identifier: an instrument column named 'Step Index' (e.g. Arbin Step_Index) maps to step_id, not to this property."@en ;
     rdfs:seeAlso unit:UNITLESS ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
@@ -425,15 +432,70 @@ schema:unitText a owl:AnnotationProperty .
         emmo:EMMO_0cd58641_824c_4851_907f_f4c3be76630c ;
     skos:altLabel "step_index"@en,
         "step_index_1"@en ;
-    skos:definition "1-based positional counter for data points within a step. Resets to 1 at the start of each new step and increments by 1 for each subsequent recorded data point. Always derivable from the data; not typically exported directly by cycler software."@en ;
+    skos:definition "1-based positional counter for data points within a step. Resets to 1 at the start of each new step and increments by 1 for each subsequent recorded data point. Always derivable from the data; not typically exported directly by cycler software. This is the within-step data-point counter, not the program step identifier: an instrument column named 'Step Index' (e.g. Arbin Step_Index) maps to step_id, not to this property."@en ;
     skos:exactMatch quantitykind:Dimensionless ;
     skos:notation "step_index" ;
     skos:prefLabel "Step Index / 1"@en ;
-    schema:description "1-based positional counter for data points within a step. Resets to 1 at the start of each new step and increments by 1 for each subsequent recorded data point. Always derivable from the data; not typically exported directly by cycler software."@en ;
+    schema:description "1-based positional counter for data points within a step. Resets to 1 at the start of each new step and increments by 1 for each subsequent recorded data point. Always derivable from the data; not typically exported directly by cycler software. This is the within-step data-point counter, not the program step identifier: an instrument column named 'Step Index' (e.g. Arbin Step_Index) maps to step_id, not to this property."@en ;
     schema:name "Step Index / 1"@en ;
     schema:unitCode "1" ;
     schema:unitText "one"@en ;
-    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "1-based positional counter for data points within a step. Resets to 1 at the start of each new step and increments by 1 for each subsequent recorded data point. Always derivable from the data; not typically exported directly by cycler software."@en .
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "1-based positional counter for data points within a step. Resets to 1 at the start of each new step and increments by 1 for each subsequent recorded data point. Always derivable from the data; not typically exported directly by cycler software. This is the within-step data-point counter, not the program step identifier: an instrument column named 'Step Index' (e.g. Arbin Step_Index) maps to step_id, not to this property."@en .
+
+:step_net_capacity_ah a owl:Class ;
+    rdfs:label "Step Net Capacity / Ah"@en ;
+    rdfs:comment "Net charge transferred during the current test step, in ampere hour. Defined as step_charging_capacity_ah minus step_discharging_capacity_ah; the running signed integral of current from the step start, reset to zero at each step transition. Can be negative if more charge is extracted than injected during the step. Increases during charge intervals and decreases during discharge intervals within the step."@en ;
+    rdfs:seeAlso unit:A-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:AmpereHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_791c1915_a791_4450_acd8_7f94764743b5 ;
+    skos:altLabel "step_net_capacity_ah"@en,
+        "step_net_capacity_ampere_hour"@en ;
+    skos:definition "Net charge transferred during the current test step, in ampere hour. Defined as step_charging_capacity_ah minus step_discharging_capacity_ah; the running signed integral of current from the step start, reset to zero at each step transition. Can be negative if more charge is extracted than injected during the step. Increases during charge intervals and decreases during discharge intervals within the step."@en ;
+    skos:exactMatch quantitykind:ElectricCharge ;
+    skos:notation "step_net_capacity_ah" ;
+    skos:prefLabel "Step Net Capacity / Ah"@en ;
+    prov:wasDerivedFrom :step_charging_capacity_ah,
+        :step_discharging_capacity_ah ;
+    schema:description "Running net capacity within the current test step: step_charging_capacity_ah - step_discharging_capacity_ah. Can be negative; resets to zero at each step transition."@en ;
+    schema:measurementTechnique "Running signed integral of current from the start of the current test step. Positive increments during charging, negative during discharging. Reset to zero at each step transition."@en ;
+    schema:name "Step Net Capacity / Ah"@en ;
+    schema:unitCode "A.h" ;
+    schema:unitText "ampere hour"@en ;
+    :latexFormula "Q_\\mathrm{net}^\\mathrm{step}(t) = Q_\\mathrm{chg}^\\mathrm{step}(t) - Q_\\mathrm{dchg}^\\mathrm{step}(t) = \\frac{1}{3600}\\int_{t_s}^{t} I(\\tau)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "Q_\\mathrm{net}^\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Net charge transferred during the current test step, in ampere hour. Defined as step_charging_capacity_ah minus step_discharging_capacity_ah; the running signed integral of current from the step start, reset to zero at each step transition. Can be negative if more charge is extracted than injected during the step. Increases during charge intervals and decreases during discharge intervals within the step."@en .
+
+:step_net_energy_wh a owl:Class ;
+    rdfs:label "Step Net Energy / Wh"@en ;
+    rdfs:comment "Net energy transferred during the current test step, in watt hour. Defined as step_charging_energy_wh minus step_discharging_energy_wh; the running signed integral of instantaneous power from the step start, reset to zero at each step transition. Can be negative if more energy is extracted than delivered during the step. Increases during charge intervals and decreases during discharge intervals within the step."@en ;
+    rdfs:seeAlso unit:W-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:WattHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_46376e5d_9627_4514_9881_9e62083625c3 ;
+    skos:altLabel "step_net_energy_watt_hour"@en,
+        "step_net_energy_wh"@en ;
+    skos:definition "Net energy transferred during the current test step, in watt hour. Defined as step_charging_energy_wh minus step_discharging_energy_wh; the running signed integral of instantaneous power from the step start, reset to zero at each step transition. Can be negative if more energy is extracted than delivered during the step. Increases during charge intervals and decreases during discharge intervals within the step."@en ;
+    skos:exactMatch quantitykind:Energy ;
+    skos:notation "step_net_energy_wh" ;
+    skos:prefLabel "Step Net Energy / Wh"@en ;
+    prov:wasDerivedFrom :step_charging_energy_wh,
+        :step_discharging_energy_wh ;
+    schema:description "Running net energy within the current test step: step_charging_energy_wh - step_discharging_energy_wh. Can be negative; resets to zero at each step transition."@en ;
+    schema:measurementTechnique "Running signed integral of instantaneous power from the start of the current test step. Positive increments during charging, negative during discharging. Reset to zero at each step transition."@en ;
+    schema:name "Step Net Energy / Wh"@en ;
+    schema:unitCode "W.h" ;
+    schema:unitText "watt hour"@en ;
+    :latexFormula "E_\\mathrm{net}^\\mathrm{step}(t) = E_\\mathrm{chg}^\\mathrm{step}(t) - E_\\mathrm{dchg}^\\mathrm{step}(t) = \\frac{1}{3600}\\int_{t_s}^{t} P(\\tau)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "E_\\mathrm{net}^\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Net energy transferred during the current test step, in watt hour. Defined as step_charging_energy_wh minus step_discharging_energy_wh; the running signed integral of instantaneous power from the step start, reset to zero at each step transition. Can be negative if more energy is extracted than delivered during the step. Increases during charge intervals and decreases during discharge intervals within the step."@en .
 
 :step_type a owl:Class ;
     rdfs:label "Step Type"@en ;
@@ -446,6 +508,7 @@ schema:unitText a owl:AnnotationProperty .
     skos:prefLabel "Step Type"@en ;
     schema:description "A string label describing the operational mode of the current test step, as reported by the cycler software. Common values include CC_CHG, CC_DCH, CV_CHG, CCCV_CHG, REST, OCV, EIS."@en ;
     schema:name "Step Type"@en ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A string label describing the operational mode of the current test step, as reported by the cycler software. Common values include CC_CHG (constant-current charge), CC_DCH (constant-current discharge), CV_CHG (constant-voltage charge), CCCV_CHG (constant-current constant-voltage charge), REST, OCV, and EIS. The controlled vocabulary for this field is not yet standardised; values should be preserved as reported by the instrument."@en .
 
 :surface_pressure_pa a owl:Class ;
@@ -467,6 +530,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Surface Pressure / Pa"@en ;
     schema:unitCode "Pa" ;
     schema:unitText "pascal"@en ;
+    :latexSymbol "p_\\mathrm{surf}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Surface pressure recorded in pascal."@en .
 
 :temperature_t1_celsius a owl:Class ;
@@ -488,6 +553,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Surface Temperature T1 / degC"@en ;
     schema:unitCode "Cel" ;
     schema:unitText "degree Celsius"@en ;
+    :latexSymbol "T_1"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "For tests with multiple temperature measurements, the measured temperature of the test object (e.g., surface or internal), in degrees Celsius."@en .
 
 :temperature_t2_celsius a owl:Class ;
@@ -509,6 +576,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Surface Temperature T2 / degC"@en ;
     schema:unitCode "Cel" ;
     schema:unitText "degree Celsius"@en ;
+    :latexSymbol "T_2"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "For tests with multiple temperature measurements, the measured temperature of the test object (e.g., surface or internal), in degrees Celsius."@en .
 
 :temperature_t3_celsius a owl:Class ;
@@ -530,6 +599,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Surface Temperature T3 / degC"@en ;
     schema:unitCode "Cel" ;
     schema:unitText "degree Celsius"@en ;
+    :latexSymbol "T_3"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "For tests with multiple temperature measurements, the measured temperature of the test object (e.g., surface or internal), in degrees Celsius."@en .
 
 :temperature_t4_celsius a owl:Class ;
@@ -551,6 +622,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Surface Temperature T4 / degC"@en ;
     schema:unitCode "Cel" ;
     schema:unitText "degree Celsius"@en ;
+    :latexSymbol "T_4"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "For tests with multiple temperature measurements, the measured temperature of the test object (e.g., surface or internal), in degrees Celsius."@en .
 
 :temperature_t5_celsius a owl:Class ;
@@ -572,6 +645,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Surface Temperature T5 / degC"@en ;
     schema:unitCode "Cel" ;
     schema:unitText "degree Celsius"@en ;
+    :latexSymbol "T_5"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "For tests with multiple temperature measurements, the measured temperature of the test object (e.g., surface or internal), in degrees Celsius."@en .
 
 :test_time_millisecond a owl:Class ;
@@ -637,6 +712,7 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Unix Time / s"@en ;
     schema:unitCode "s" ;
     schema:unitText "second"@en ;
+    :obligation "recommended" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Unix time recorded in second."@en .
 
 :charging_capacity_ah a owl:Class ;
@@ -660,6 +736,9 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Charging Capacity / Ah"@en ;
     schema:unitCode "A.h" ;
     schema:unitText "ampere hour"@en ;
+    :latexFormula "Q_\\mathrm{chg}(t) = \\frac{1}{3600}\\int_0^t \\max\\!\\bigl(I(\\tau),\\,0\\bigr)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "Q_\\mathrm{chg}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Cumulative electric charge transferred into the test object during charging, in ampere hour. Accumulates from the start of the test and never resets between steps or cycles. Increases only during charge intervals; unchanged during rest or discharge. Note: differs from step-level Q charge as reported by some instruments (e.g. BioLogic EC-Lab), which reset to zero at each step boundary."@en .
 
 :charging_energy_wh a owl:Class ;
@@ -683,6 +762,9 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Charging Energy / Wh"@en ;
     schema:unitCode "W.h" ;
     schema:unitText "watt hour"@en ;
+    :latexFormula "E_\\mathrm{chg}(t) = \\frac{1}{3600}\\int_0^t \\max\\!\\bigl(P(\\tau),\\,0\\bigr)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "E_\\mathrm{chg}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Cumulative energy transferred into the test object during charging, in watt hour. Accumulates from the start of the test and never resets between steps or cycles. Increases only during charge intervals; unchanged during rest or discharge."@en .
 
 :discharging_capacity_ah a owl:Class ;
@@ -706,6 +788,9 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Discharging Capacity / Ah"@en ;
     schema:unitCode "A.h" ;
     schema:unitText "ampere hour"@en ;
+    :latexFormula "Q_\\mathrm{dchg}(t) = \\frac{1}{3600}\\int_0^t \\max\\!\\bigl(-I(\\tau),\\,0\\bigr)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "Q_\\mathrm{dchg}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Cumulative electric charge transferred out of the test object during discharging, in ampere hour. Accumulates from the start of the test and never resets between steps or cycles. Increases only during discharge intervals; unchanged during rest or charge. Note: differs from step-level Q discharge as reported by some instruments (e.g. BioLogic EC-Lab), which reset to zero at each step boundary."@en .
 
 :discharging_energy_wh a owl:Class ;
@@ -729,7 +814,184 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Discharging Energy / Wh"@en ;
     schema:unitCode "W.h" ;
     schema:unitText "watt hour"@en ;
+    :latexFormula "E_\\mathrm{dchg}(t) = \\frac{1}{3600}\\int_0^t \\max\\!\\bigl(-P(\\tau),\\,0\\bigr)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "E_\\mathrm{dchg}"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Cumulative energy transferred out of the test object during discharging, in watt hour. Accumulates from the start of the test and never resets between steps or cycles. Increases only during discharge intervals; unchanged during rest or charge."@en .
+
+:step_charging_capacity_ah a owl:Class ;
+    rdfs:label "Step Charging Capacity / Ah"@en ;
+    rdfs:comment "Electric charge transferred into the test object during the charge portion of the current test step, in ampere hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the positive part of current over the step. Equivalent to the step-level charge capacity reported by some instruments (e.g. BioLogic EC-Lab Q charge), which reset at each step boundary."@en ;
+    rdfs:seeAlso unit:A-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:AmpereHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_10763eb0_dbc9_4d34_bd1a_7b8996590d45 ;
+    skos:altLabel "step_charge_capacity_ah"@en,
+        "step_charging_capacity_ah"@en,
+        "step_charging_capacity_ampere_hour"@en ;
+    skos:definition "Electric charge transferred into the test object during the charge portion of the current test step, in ampere hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the positive part of current over the step. Equivalent to the step-level charge capacity reported by some instruments (e.g. BioLogic EC-Lab Q charge), which reset at each step boundary."@en ;
+    skos:exactMatch quantitykind:ElectricCharge ;
+    skos:notation "step_charging_capacity_ah" ;
+    skos:prefLabel "Step Charging Capacity / Ah"@en ;
+    prov:wasDerivedFrom :current_ampere,
+        :step_time_second ;
+    schema:description "Electric charge transferred into the test object during the charge portion of the current test step, in ampere hour. Non-negative; resets to zero at each step transition."@en ;
+    schema:measurementTechnique "Time integral of the positive part of current over the duration of the current test step."@en ;
+    schema:name "Step Charging Capacity / Ah"@en ;
+    schema:unitCode "A.h" ;
+    schema:unitText "ampere hour"@en ;
+    :latexFormula "Q_\\mathrm{chg}^\\mathrm{step}(t) = \\frac{1}{3600}\\int_{t_s}^{t} \\max\\!\\bigl(I(\\tau),\\,0\\bigr)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "Q_\\mathrm{chg}^\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Electric charge transferred into the test object during the charge portion of the current test step, in ampere hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the positive part of current over the step. Equivalent to the step-level charge capacity reported by some instruments (e.g. BioLogic EC-Lab Q charge), which reset at each step boundary."@en .
+
+:step_charging_energy_wh a owl:Class ;
+    rdfs:label "Step Charging Energy / Wh"@en ;
+    rdfs:comment "Energy transferred into the test object during the charge portion of the current test step, in watt hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the positive part of instantaneous power over the step."@en ;
+    rdfs:seeAlso unit:W-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:WattHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_2ab7af60_da58_4243_b3bc_cbb2155cac53 ;
+    skos:altLabel "step_charge_energy_wh"@en,
+        "step_charging_energy_watt_hour"@en,
+        "step_charging_energy_wh"@en ;
+    skos:definition "Energy transferred into the test object during the charge portion of the current test step, in watt hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the positive part of instantaneous power over the step."@en ;
+    skos:exactMatch quantitykind:Energy ;
+    skos:notation "step_charging_energy_wh" ;
+    skos:prefLabel "Step Charging Energy / Wh"@en ;
+    prov:wasDerivedFrom :power_watt,
+        :step_time_second ;
+    schema:description "Energy transferred into the test object during the charge portion of the current test step, in watt hour. Non-negative; resets to zero at each step transition."@en ;
+    schema:measurementTechnique "Time integral of the positive part of instantaneous power over the duration of the current test step."@en ;
+    schema:name "Step Charging Energy / Wh"@en ;
+    schema:unitCode "W.h" ;
+    schema:unitText "watt hour"@en ;
+    :latexFormula "E_\\mathrm{chg}^\\mathrm{step}(t) = \\frac{1}{3600}\\int_{t_s}^{t} \\max\\!\\bigl(P(\\tau),\\,0\\bigr)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "E_\\mathrm{chg}^\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Energy transferred into the test object during the charge portion of the current test step, in watt hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the positive part of instantaneous power over the step."@en .
+
+:step_cumulative_capacity_ah a owl:Class ;
+    rdfs:label "Step Cumulative Capacity / Ah"@en ;
+    dcterms:replaces :step_capacity_ah ;
+    rdfs:comment "Running accumulation of charge throughput within the current test step, in ampere hour. Monotonically non-decreasing within the step; resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en,
+        "Running accumulation of charge throughput within the current test step, in ampere hour: the time integral of the absolute current from the step start, monotonically non-decreasing within the step and reset to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value. Instruments that export this quantity directly are accepted as-is; where it must be computed, it is the time integral of the absolute current over the step duration."@en ;
+    rdfs:seeAlso unit:A-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:AmpereHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_ae108db7_8765_4329_9908_059277dee586 ;
+    skos:altLabel "step_capacity_ah"@en,
+        "step_cumulative_capacity_ah"@en,
+        "step_cumulative_capacity_ampere_hour"@en ;
+    skos:definition "Running accumulation of charge throughput within the current test step, in ampere hour: the time integral of the absolute current from the step start, monotonically non-decreasing within the step and reset to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value. Instruments that export this quantity directly are accepted as-is; where it must be computed, it is the time integral of the absolute current over the step duration."@en ;
+    skos:exactMatch quantitykind:ElectricCharge ;
+    skos:notation "step_cumulative_capacity_ah" ;
+    skos:prefLabel "Step Cumulative Capacity / Ah"@en ;
+    prov:wasDerivedFrom :current_ampere,
+        :step_time_second ;
+    prov:wasRevisionOf :step_capacity_ah ;
+    schema:description "Running accumulation of charge throughput within the current test step, in ampere hour. Monotonically non-decreasing within the step; resets to zero at each step transition."@en ;
+    schema:measurementTechnique "Time integral of the absolute value of current from the start of the current test step."@en ;
+    schema:name "Step Cumulative Capacity / Ah"@en ;
+    schema:unitCode "A.h" ;
+    schema:unitText "ampere hour"@en ;
+    :latexFormula "Q_\\mathrm{cum}^\\mathrm{step}(t) = Q_\\mathrm{chg}^\\mathrm{step}(t) + Q_\\mathrm{dchg}^\\mathrm{step}(t) = \\frac{1}{3600}\\int_{t_s}^{t} \\bigl|I(\\tau)\\bigr|\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "Q_\\mathrm{cum}^\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Running accumulation of charge throughput within the current test step, in ampere hour. Monotonically non-decreasing within the step; resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en .
+
+:step_cumulative_energy_wh a owl:Class ;
+    rdfs:label "Step Cumulative Energy / Wh"@en ;
+    dcterms:replaces :step_energy_wh ;
+    rdfs:comment "Running accumulation of energy throughput within the current test step, in watt hour. Monotonically non-decreasing within the step; resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en,
+        "Running accumulation of energy throughput within the current test step, in watt hour: the time integral of the absolute instantaneous power from the step start, monotonically non-decreasing within the step and reset to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value. Instruments that export this quantity directly are accepted as-is; where it must be computed, it is the time integral of the absolute instantaneous power over the step duration."@en ;
+    rdfs:seeAlso unit:W-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:WattHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_46376e5d_9627_4514_9881_9e62083625c3 ;
+    skos:altLabel "step_cumulative_energy_watt_hour"@en,
+        "step_cumulative_energy_wh"@en,
+        "step_energy_wh"@en ;
+    skos:definition "Running accumulation of energy throughput within the current test step, in watt hour: the time integral of the absolute instantaneous power from the step start, monotonically non-decreasing within the step and reset to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value. Instruments that export this quantity directly are accepted as-is; where it must be computed, it is the time integral of the absolute instantaneous power over the step duration."@en ;
+    skos:exactMatch quantitykind:Energy ;
+    skos:notation "step_cumulative_energy_wh" ;
+    skos:prefLabel "Step Cumulative Energy / Wh"@en ;
+    prov:wasDerivedFrom :power_watt,
+        :step_time_second ;
+    prov:wasRevisionOf :step_energy_wh ;
+    schema:description "Running accumulation of energy throughput within the current test step, in watt hour. Monotonically non-decreasing within the step; resets to zero at each step transition."@en ;
+    schema:measurementTechnique "Time integral of the absolute value of instantaneous power from the start of the current test step."@en ;
+    schema:name "Step Cumulative Energy / Wh"@en ;
+    schema:unitCode "W.h" ;
+    schema:unitText "watt hour"@en ;
+    :latexFormula "E_\\mathrm{cum}^\\mathrm{step}(t) = E_\\mathrm{chg}^\\mathrm{step}(t) + E_\\mathrm{dchg}^\\mathrm{step}(t) = \\frac{1}{3600}\\int_{t_s}^{t} \\bigl|P(\\tau)\\bigr|\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "E_\\mathrm{cum}^\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Running accumulation of energy throughput within the current test step, in watt hour. Monotonically non-decreasing within the step; resets to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en .
+
+:step_discharging_capacity_ah a owl:Class ;
+    rdfs:label "Step Discharging Capacity / Ah"@en ;
+    rdfs:comment "Electric charge transferred out of the test object during the discharge portion of the current test step, in ampere hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the negated negative part of current over the step. Equivalent to the step-level discharge capacity reported by some instruments (e.g. BioLogic EC-Lab Q discharge), which reset at each step boundary."@en ;
+    rdfs:seeAlso unit:A-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:AmpereHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_0141b5c2_9f15_46f4_82e6_92a104faa476 ;
+    skos:altLabel "step_discharge_capacity_ah"@en,
+        "step_discharging_capacity_ah"@en,
+        "step_discharging_capacity_ampere_hour"@en ;
+    skos:definition "Electric charge transferred out of the test object during the discharge portion of the current test step, in ampere hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the negated negative part of current over the step. Equivalent to the step-level discharge capacity reported by some instruments (e.g. BioLogic EC-Lab Q discharge), which reset at each step boundary."@en ;
+    skos:exactMatch quantitykind:ElectricCharge ;
+    skos:notation "step_discharging_capacity_ah" ;
+    skos:prefLabel "Step Discharging Capacity / Ah"@en ;
+    prov:wasDerivedFrom :current_ampere,
+        :step_time_second ;
+    schema:description "Electric charge transferred out of the test object during the discharge portion of the current test step, in ampere hour. Non-negative; resets to zero at each step transition."@en ;
+    schema:measurementTechnique "Time integral of the negated negative part of current over the duration of the current test step."@en ;
+    schema:name "Step Discharging Capacity / Ah"@en ;
+    schema:unitCode "A.h" ;
+    schema:unitText "ampere hour"@en ;
+    :latexFormula "Q_\\mathrm{dchg}^\\mathrm{step}(t) = \\frac{1}{3600}\\int_{t_s}^{t} \\max\\!\\bigl(-I(\\tau),\\,0\\bigr)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "Q_\\mathrm{dchg}^\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Electric charge transferred out of the test object during the discharge portion of the current test step, in ampere hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the negated negative part of current over the step. Equivalent to the step-level discharge capacity reported by some instruments (e.g. BioLogic EC-Lab Q discharge), which reset at each step boundary."@en .
+
+:step_discharging_energy_wh a owl:Class ;
+    rdfs:label "Step Discharging Energy / Wh"@en ;
+    rdfs:comment "Energy transferred out of the test object during the discharge portion of the current test step, in watt hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the negated negative part of instantaneous power over the step."@en ;
+    rdfs:seeAlso unit:W-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:WattHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_ca36cbf3_1fed_4b88_9177_b4e16ad00cf7 ;
+    skos:altLabel "step_discharge_energy_wh"@en,
+        "step_discharging_energy_watt_hour"@en,
+        "step_discharging_energy_wh"@en ;
+    skos:definition "Energy transferred out of the test object during the discharge portion of the current test step, in watt hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the negated negative part of instantaneous power over the step."@en ;
+    skos:exactMatch quantitykind:Energy ;
+    skos:notation "step_discharging_energy_wh" ;
+    skos:prefLabel "Step Discharging Energy / Wh"@en ;
+    prov:wasDerivedFrom :power_watt,
+        :step_time_second ;
+    schema:description "Energy transferred out of the test object during the discharge portion of the current test step, in watt hour. Non-negative; resets to zero at each step transition."@en ;
+    schema:measurementTechnique "Time integral of the negated negative part of instantaneous power over the duration of the current test step."@en ;
+    schema:name "Step Discharging Energy / Wh"@en ;
+    schema:unitCode "W.h" ;
+    schema:unitText "watt hour"@en ;
+    :latexFormula "E_\\mathrm{dchg}^\\mathrm{step}(t) = \\frac{1}{3600}\\int_{t_s}^{t} \\max\\!\\bigl(-P(\\tau),\\,0\\bigr)\\,\\mathrm{d}\\tau"^^xsd:string ;
+    :latexSymbol "E_\\mathrm{dchg}^\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Energy transferred out of the test object during the discharge portion of the current test step, in watt hour. Non-negative (≥ 0); resets to zero at each step transition. Where computed, it is the time integral of the negated negative part of instantaneous power over the step."@en .
 
 :voltage_volt a owl:Class ;
     rdfs:label "Voltage / V"@en ;
@@ -750,6 +1012,8 @@ schema:unitText a owl:AnnotationProperty .
     schema:name "Voltage / V"@en ;
     schema:unitCode "V" ;
     schema:unitText "volt"@en ;
+    :latexSymbol "V"^^xsd:string ;
+    :obligation "required" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Instantaneous voltage recorded in volt."@en .
 
 emmo:Ampere a owl:Class .
@@ -771,7 +1035,9 @@ emmo:Volt a owl:Class .
     skos:notation "imaginary_impedance_ohm"@en ;
     skos:prefLabel "Imaginary Impedance / ohm"@en ;
     schema:unitCode "Ohm" ;
-    schema:unitText "ohm"@en .
+    schema:unitText "ohm"@en ;
+    :latexSymbol "Z''"^^xsd:string ;
+    :obligation "optional" .
 
 :real_impedance_ohm a owl:Class ;
     rdfs:label "Real Impedance / ohm"@en ;
@@ -784,28 +1050,86 @@ emmo:Volt a owl:Class .
     skos:notation "real_impedance_ohm"@en ;
     skos:prefLabel "Real Impedance / ohm"@en ;
     schema:unitCode "Ohm" ;
-    schema:unitText "ohm"@en .
+    schema:unitText "ohm"@en ;
+    :latexSymbol "Z'"^^xsd:string ;
+    :obligation "optional" .
 
-:step_time_second a owl:Class ;
-    rdfs:label "Step Time / s"@en ;
-    rdfs:comment "the elapsed time since the beginning of the active test step, measured in seconds and reset at each step transition"@en ;
-    rdfs:seeAlso unit:SEC ;
-    rdfs:subClassOf sosa:ObservableProperty,
-        electrochemistry:electrochemistry_80ca00f8_c891_4493_87a2_7d39b9d1e098 ;
-    skos:altLabel "step_time_second"@en ;
-    skos:definition "the elapsed time since the beginning of the active test step, measured in seconds and reset at each step transition"@en ;
-    skos:exactMatch quantitykind:Time ;
-    skos:notation "step_time_second"@en ;
-    skos:prefLabel "Step Time / s"@en ;
-    schema:description "the elapsed time since the beginning of the active test step, measured in seconds and reset at each step transition"@en ;
-    schema:name "Step Time / s"@en ;
-    schema:unitCode "s" ;
-    schema:unitText "second"@en ;
-    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "the elapsed time since the beginning of the active test step, measured in seconds and reset at each step transition"@en .
+:step_capacity_ah a owl:Class ;
+    rdfs:label "Step Capacity / Ah"@en ;
+    dcterms:isReplacedBy :step_cumulative_capacity_ah ;
+    rdfs:comment "Running accumulation of charge throughput within the current test step, in ampere hour. Monotonically non-decreasing within the step; resets to zero at each step transition."@en,
+        "Running accumulation of charge throughput within the current test step, in ampere hour: the time integral of the absolute current from the step start, monotonically non-decreasing within the step and reset to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en ;
+    rdfs:seeAlso unit:A-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:AmpereHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_ae108db7_8765_4329_9908_059277dee586 ;
+    owl:deprecated true ;
+    skos:altLabel "step_capacity_ah"@en,
+        "step_capacity_ampere_hour"@en ;
+    skos:definition "Running accumulation of charge throughput within the current test step, in ampere hour: the time integral of the absolute current from the step start, monotonically non-decreasing within the step and reset to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en ;
+    skos:exactMatch quantitykind:ElectricCharge ;
+    skos:historyNote "Deprecated in 1.1.0 (2026-06-08). Renamed to step_cumulative_capacity_ah for consistency with the {charging, discharging, net, cumulative} convention; the concept is unchanged."@en ;
+    skos:notation "step_capacity_ah" ;
+    skos:prefLabel "Step Capacity / Ah"@en ;
+    schema:description "Running accumulation of charge throughput within the current test step, in ampere hour. Monotonically non-decreasing within the step; resets to zero at each step transition."@en ;
+    schema:name "Step Capacity / Ah"@en ;
+    schema:unitCode "A.h" ;
+    schema:unitText "ampere hour"@en ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Running accumulation of charge throughput within the current test step, in ampere hour. Monotonically non-decreasing within the step; resets to zero at each step transition."@en .
+
+:step_energy_wh a owl:Class ;
+    rdfs:label "Step Energy / Wh"@en ;
+    dcterms:isReplacedBy :step_cumulative_energy_wh ;
+    rdfs:comment "Running accumulation of energy throughput within the current test step, in watt hour. Monotonically non-decreasing within the step; resets to zero at each step transition."@en,
+        "Running accumulation of energy throughput within the current test step, in watt hour: the time integral of the absolute instantaneous power from the step start, monotonically non-decreasing within the step and reset to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en ;
+    rdfs:seeAlso unit:W-HR ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:WattHour ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_46376e5d_9627_4514_9881_9e62083625c3 ;
+    owl:deprecated true ;
+    skos:altLabel "step_energy_watt_hour"@en,
+        "step_energy_wh"@en ;
+    skos:definition "Running accumulation of energy throughput within the current test step, in watt hour: the time integral of the absolute instantaneous power from the step start, monotonically non-decreasing within the step and reset to zero at each step transition. The direction of transfer is indicated by step_type or the sign of current_ampere, not by this value."@en ;
+    skos:exactMatch quantitykind:Energy ;
+    skos:historyNote "Deprecated in 1.1.0 (2026-06-08). Renamed to step_cumulative_energy_wh for consistency with the {charging, discharging, net, cumulative} convention; the concept is unchanged."@en ;
+    skos:notation "step_energy_wh" ;
+    skos:prefLabel "Step Energy / Wh"@en ;
+    schema:description "Running accumulation of energy throughput within the current test step, in watt hour. Monotonically non-decreasing within the step; resets to zero at each step transition."@en ;
+    schema:name "Step Energy / Wh"@en ;
+    schema:unitCode "W.h" ;
+    schema:unitText "watt hour"@en ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Running accumulation of energy throughput within the current test step, in watt hour. Monotonically non-decreasing within the step; resets to zero at each step transition."@en .
 
 emmo:MilliSecond a owl:Class .
 
 emmo:Second a owl:Class .
+
+:surface_temperature_celsius a owl:Class ;
+    rdfs:label "Surface Temperature / degC"@en ;
+    rdfs:comment "Surface temperature recorded in degree Celsius."@en ;
+    rdfs:seeAlso unit:DEG_C ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:DegreeCelsius ],
+        sosa:ObservableProperty,
+        emmo:EMMO_66bc9029_f473_45ff_bab9_c3509ff37a22 ;
+    skos:altLabel "surface_temperature_celsius"@en,
+        "surface_temperature_degc"@en ;
+    skos:definition "Surface temperature recorded in degree Celsius."@en ;
+    skos:exactMatch quantitykind:Temperature ;
+    skos:notation "surface_temperature_celsius" ;
+    skos:prefLabel "Surface Temperature / degC"@en ;
+    schema:description "Surface temperature recorded in degree Celsius."@en ;
+    schema:name "Surface Temperature / degC"@en ;
+    schema:unitCode "Cel" ;
+    schema:unitText "degree Celsius"@en ;
+    :latexSymbol "T_\\mathrm{surf}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Surface temperature recorded in degree Celsius."@en .
 
 :power_watt a owl:Class ;
     rdfs:label "Power / W"@en ;
@@ -829,53 +1153,29 @@ emmo:Second a owl:Class .
     schema:name "Power / W"@en ;
     schema:unitCode "W" ;
     schema:unitText "watt"@en ;
+    :latexFormula "P(t) = V(t)\\,I(t)"^^xsd:string ;
+    :latexSymbol "P"^^xsd:string ;
+    :obligation "optional" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Instantaneous power calculated as the product of voltage and current, in watt."@en .
 
-:current_ampere a owl:Class ;
-    rdfs:label "Current / A"@en ;
-    rdfs:comment "Instantaneous current recorded in ampere."@en ;
-    rdfs:seeAlso unit:A ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
-            owl:someValuesFrom emmo:Ampere ],
-        sosa:ObservableProperty,
-        electrochemistry:electrochemistry_a24f8581_a5a4_41a4_bb45_d0fdd5c0d810 ;
-    skos:altLabel "current_a"@en,
-        "current_ampere"@en ;
-    skos:definition "Instantaneous current recorded in ampere."@en ;
-    skos:exactMatch quantitykind:ElectricCurrent ;
-    skos:notation "current_ampere" ;
-    skos:prefLabel "Current / A"@en ;
-    schema:description "Instantaneous current recorded in ampere."@en ;
-    schema:name "Current / A"@en ;
-    schema:unitCode "A" ;
-    schema:unitText "ampere"@en ;
-    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Instantaneous current recorded in ampere."@en .
-
-:surface_temperature_celsius a owl:Class ;
-    rdfs:label "Surface Temperature / degC"@en ;
-    rdfs:comment "Surface temperature recorded in degree Celsius."@en ;
-    rdfs:seeAlso unit:DEG_C ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
-            owl:someValuesFrom emmo:DegreeCelsius ],
-        sosa:ObservableProperty,
-        emmo:EMMO_66bc9029_f473_45ff_bab9_c3509ff37a22 ;
-    skos:altLabel "surface_temperature_celsius"@en,
-        "surface_temperature_degc"@en ;
-    skos:definition "Surface temperature recorded in degree Celsius."@en ;
-    skos:exactMatch quantitykind:Temperature ;
-    skos:notation "surface_temperature_celsius" ;
-    skos:prefLabel "Surface Temperature / degC"@en ;
-    schema:description "Surface temperature recorded in degree Celsius."@en ;
-    schema:name "Surface Temperature / degC"@en ;
-    schema:unitCode "Cel" ;
-    schema:unitText "degree Celsius"@en ;
-    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Surface temperature recorded in degree Celsius."@en .
-
-emmo:AmpereHour a owl:Class .
-
-emmo:WattHour a owl:Class .
+:step_time_second a owl:Class ;
+    rdfs:label "Step Time / s"@en ;
+    rdfs:comment "the elapsed time since the beginning of the active test step, measured in seconds and reset at each step transition"@en ;
+    rdfs:seeAlso unit:SEC ;
+    rdfs:subClassOf sosa:ObservableProperty,
+        electrochemistry:electrochemistry_80ca00f8_c891_4493_87a2_7d39b9d1e098 ;
+    skos:altLabel "step_time_second"@en ;
+    skos:definition "the elapsed time since the beginning of the active test step, measured in seconds and reset at each step transition"@en ;
+    skos:exactMatch quantitykind:Time ;
+    skos:notation "step_time_second"@en ;
+    skos:prefLabel "Step Time / s"@en ;
+    schema:description "the elapsed time since the beginning of the active test step, measured in seconds and reset at each step transition"@en ;
+    schema:name "Step Time / s"@en ;
+    schema:unitCode "s" ;
+    schema:unitText "second"@en ;
+    :latexSymbol "\\Delta t_\\mathrm{step}"^^xsd:string ;
+    :obligation "optional" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "the elapsed time since the beginning of the active test step, measured in seconds and reset at each step transition"@en .
 
 :test_time_second a owl:Class ;
     rdfs:label "Test Time / s"@en ;
@@ -896,9 +1196,38 @@ emmo:WattHour a owl:Class .
     schema:name "Test Time / s"@en ;
     schema:unitCode "s" ;
     schema:unitText "second"@en ;
+    :latexSymbol "t"^^xsd:string ;
+    :obligation "required" ;
     emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Test time recorded in second."@en .
 
+:current_ampere a owl:Class ;
+    rdfs:label "Current / A"@en ;
+    rdfs:comment "Instantaneous current recorded in ampere."@en ;
+    rdfs:seeAlso unit:A ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty emmo:EMMO_bed1d005_b04e_4a90_94cf_02bc678a8569 ;
+            owl:someValuesFrom emmo:Ampere ],
+        sosa:ObservableProperty,
+        electrochemistry:electrochemistry_a24f8581_a5a4_41a4_bb45_d0fdd5c0d810 ;
+    skos:altLabel "current_a"@en,
+        "current_ampere"@en ;
+    skos:definition "Instantaneous current recorded in ampere."@en ;
+    skos:exactMatch quantitykind:ElectricCurrent ;
+    skos:notation "current_ampere" ;
+    skos:prefLabel "Current / A"@en ;
+    schema:description "Instantaneous current recorded in ampere."@en ;
+    schema:name "Current / A"@en ;
+    schema:unitCode "A" ;
+    schema:unitText "ampere"@en ;
+    :latexSymbol "I"^^xsd:string ;
+    :obligation "required" ;
+    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Instantaneous current recorded in ampere."@en .
+
 emmo:DegreeCelsius a owl:Class .
+
+emmo:AmpereHour a owl:Class .
+
+emmo:WattHour a owl:Class .
 
 sosa:ObservableProperty a owl:Class .
 


### PR DESCRIPTION
The live ontology published the step-directional quantities (step_charging/discharging/cumulative/net_* capacity & energy), so the bundled snapshot became stale and test_bundled_snapshot_is_up_to_date started failing on main (it compares the bundled snapshot against live).

Regenerate via ColumnOntology.get_snapshot() so the bundled snapshot matches the published 1.0.0 ontology again.