### PR TITLE
ci: enforce socket blocking for cache-backed network tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,20 @@ jobs:
       - name: Compute content-addressed cache key (offline)
         id: key
         run: echo "k=bdf-data-$(uv run python scripts/warm_cache.py --emit-key)" >> "$GITHUB_OUTPUT"
-      - name: Restore/save warmed cache
-        uses: actions/cache@v4
+      - name: Restore warmed cache
+        id: restore
+        uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.bdf-cache
           key: ${{ steps.key.outputs.k }}
       - name: Warm cache
         run: uv run python scripts/warm_cache.py
+      - name: Save warmed cache
+        if: success() && steps.restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.bdf-cache
+          key: ${{ steps.key.outputs.k }}
 
   network-tests:
     needs: warm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Warm cache
         run: uv run python scripts/warm_cache.py
 
-  network-testa:
+  network-tests:
     needs: warm-cache
     runs-on: ubuntu-latest
     strategy:
@@ -104,5 +104,5 @@ jobs:
         with:
           path: ${{ github.workspace }}/.bdf-cache
           key: ${{ needs.warm-cache.outputs.cache-key }}
-      - name: Run tests (network)
-        run: uv run --all-extras pytest -q -m network
+      - name: Run tests (network, cache-backed sockets blocked)
+        run: uv run --all-extras pytest -q -m network --block-cached-sockets

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ examples/out/
 examples/in/raw_data_collection/g20m7/**
 examples/in/raw_data_collection/nacr32140mp10/**
 **/metadata.jsonld
+# committed registry snapshot used by examples/registry.ipynb (offline / CI)
+!examples/in/registry/**/metadata.jsonld
 
 # Coding agents
 *claude*

--- a/examples/in/registry/google/g20m7/202512/c5hnd9/metadata.jsonld
+++ b/examples/in/registry/google/g20m7/202512/c5hnd9/metadata.jsonld
@@ -1,0 +1,142 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/google/g20m7/202512/c5hnd9",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Cobalt",
+        "rdfs:label": "Cobalt"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.9,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 4.835,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 18.8,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 63,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.02925,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP6/65/75"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "prismatic"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 4.835
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 18.8
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 63
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.02925
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "c5hnd9",
+    "ICP6/65/75"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Google"
+  },
+  "schema:model": "G20M7",
+  "schema:name": "google-g20m7-202512-c5hnd9",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-c5hnd9__20260109__C30__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-c5hnd9__20260112__HPPC__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/google/g20m7/202512/gru6mv/metadata.jsonld
+++ b/examples/in/registry/google/g20m7/202512/gru6mv/metadata.jsonld
@@ -1,0 +1,139 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/google/g20m7/202512/gru6mv",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Cobalt",
+        "rdfs:label": "Cobalt"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.9,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 4.835,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 18.8,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 63,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.02925,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP6/65/75"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "prismatic"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 4.835
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 18.8
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 63
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.02925
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "gru6mv",
+    "ICP6/65/75"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Google"
+  },
+  "schema:model": "G20M7",
+  "schema:name": "google-g20m7-202512-gru6mv",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-gru6mv__20260109__HPPC__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/google/g20m7/202512/kcsb0s/metadata.jsonld
+++ b/examples/in/registry/google/g20m7/202512/kcsb0s/metadata.jsonld
@@ -1,0 +1,142 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/google/g20m7/202512/kcsb0s",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Cobalt",
+        "rdfs:label": "Cobalt"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.9,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 4.835,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 18.8,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 63,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.02925,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP6/65/75"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "prismatic"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 4.835
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 18.8
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 63
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.02925
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "kcsb0s",
+    "ICP6/65/75"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Google"
+  },
+  "schema:model": "G20M7",
+  "schema:name": "google-g20m7-202512-kcsb0s",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-kcsb0s__20260109__C5__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-kcsb0s__20260109__ICI__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/google/g20m7/202512/metadata.jsonld
+++ b/examples/in/registry/google/g20m7/202512/metadata.jsonld
@@ -1,0 +1,514 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "http://www.w3.org/ns/csvw"
+  ],
+  "@type": "schema:Dataset",
+  "schema:creator": [
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Clark",
+      "schema:givenName": "Simon",
+      "schema:name": "Simon Clark",
+      "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Martinsen",
+      "schema:givenName": "Stig Yngve",
+      "schema:name": "Stig Yngve Martinsen",
+      "schema:sameAs": "https://orcid.org/0009-0004-8522-9900"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Tolchard",
+      "schema:givenName": "Julian",
+      "schema:name": "Julian Tolchard",
+      "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+    }
+  ],
+  "schema:description": "Performance data for the G20M7 lithium-ion battery used in Google Pixel 10 mobile phones.",
+  "schema:hasPart": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-c5hnd9__20260109__C30__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/google/g20m7/202512/c5hnd9"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Martinsen",
+          "schema:givenName": "Stig Yngve",
+          "schema:name": "Stig Yngve Martinsen",
+          "schema:sameAs": "https://orcid.org/0009-0004-8522-9900"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the G20M7 lithium-ion battery used in Google Pixel 10 mobile phones. Measurement technique: C30.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-c5hnd9__20260109__C30__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-c5hnd9__20260109__C30__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__google-g20m7-202512-c5hnd9__20260109__C30__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__google-g20m7-202512-c5hnd9__20260109__C30__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "g20m7",
+        "battery",
+        "icp6/65/75",
+        "hppc",
+        "ici",
+        "gitt"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C30",
+      "schema:name": "Google Pixel 10 Battery \u2013 G20M7 Lithium-Ion Cell Test Data - C30",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "0.1.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-c5hnd9__20260112__HPPC__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/google/g20m7/202512/c5hnd9"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Martinsen",
+          "schema:givenName": "Stig Yngve",
+          "schema:name": "Stig Yngve Martinsen",
+          "schema:sameAs": "https://orcid.org/0009-0004-8522-9900"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the G20M7 lithium-ion battery used in Google Pixel 10 mobile phones. Measurement technique: HPPC.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-c5hnd9__20260112__HPPC__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-c5hnd9__20260112__HPPC__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__google-g20m7-202512-c5hnd9__20260112__HPPC__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__google-g20m7-202512-c5hnd9__20260112__HPPC__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "g20m7",
+        "battery",
+        "icp6/65/75",
+        "hppc",
+        "ici",
+        "gitt"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC",
+      "schema:name": "Google Pixel 10 Battery \u2013 G20M7 Lithium-Ion Cell Test Data - HPPC",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "0.1.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-gru6mv__20260109__HPPC__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/google/g20m7/202512/gru6mv"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Martinsen",
+          "schema:givenName": "Stig Yngve",
+          "schema:name": "Stig Yngve Martinsen",
+          "schema:sameAs": "https://orcid.org/0009-0004-8522-9900"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the G20M7 lithium-ion battery used in Google Pixel 10 mobile phones. Measurement technique: HPPC.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-gru6mv__20260109__HPPC__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-gru6mv__20260109__HPPC__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__google-g20m7-202512-gru6mv__20260109__HPPC__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__google-g20m7-202512-gru6mv__20260109__HPPC__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "g20m7",
+        "battery",
+        "icp6/65/75",
+        "hppc",
+        "ici",
+        "gitt"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC",
+      "schema:name": "Google Pixel 10 Battery \u2013 G20M7 Lithium-Ion Cell Test Data - HPPC",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "0.1.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-kcsb0s__20260109__C5__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/google/g20m7/202512/kcsb0s"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Martinsen",
+          "schema:givenName": "Stig Yngve",
+          "schema:name": "Stig Yngve Martinsen",
+          "schema:sameAs": "https://orcid.org/0009-0004-8522-9900"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the G20M7 lithium-ion battery used in Google Pixel 10 mobile phones. Measurement technique: C5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-kcsb0s__20260109__C5__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-kcsb0s__20260109__C5__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__google-g20m7-202512-kcsb0s__20260109__C5__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__google-g20m7-202512-kcsb0s__20260109__C5__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "g20m7",
+        "battery",
+        "icp6/65/75",
+        "hppc",
+        "ici",
+        "gitt"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C5",
+      "schema:name": "Google Pixel 10 Battery \u2013 G20M7 Lithium-Ion Cell Test Data - C5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "0.1.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-kcsb0s__20260109__ICI__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/google/g20m7/202512/kcsb0s"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Martinsen",
+          "schema:givenName": "Stig Yngve",
+          "schema:name": "Stig Yngve Martinsen",
+          "schema:sameAs": "https://orcid.org/0009-0004-8522-9900"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the G20M7 lithium-ion battery used in Google Pixel 10 mobile phones. Measurement technique: ICI.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-kcsb0s__20260109__ICI__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/google/g20m7/202512/data/SINTEF__google-g20m7-202512-kcsb0s__20260109__ICI__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__google-g20m7-202512-kcsb0s__20260109__ICI__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__google-g20m7-202512-kcsb0s__20260109__ICI__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "g20m7",
+        "battery",
+        "icp6/65/75",
+        "hppc",
+        "ici",
+        "gitt"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "ICI",
+      "schema:name": "Google Pixel 10 Battery \u2013 G20M7 Lithium-Ion Cell Test Data - ICI",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "0.1.0"
+    }
+  ],
+  "schema:inLanguage": "en",
+  "schema:keywords": [
+    "li-ion",
+    "g20m7",
+    "battery",
+    "icp6/65/75",
+    "hppc",
+    "ici",
+    "gitt"
+  ],
+  "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+  "schema:name": "Google Pixel 10 Battery \u2013 G20M7 Lithium-Ion Cell Test Data",
+  "schema:url": "https://github.com/digibatt/battery-data/google/g20m7/202512",
+  "schema:variableMeasured": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Test Time",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+      "schema:unitText": "s"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Voltage",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+      "schema:unitText": "V"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Current",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+      "schema:unitText": "A"
+    }
+  ],
+  "schema:version": "0.1.0"
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/3gvjz6/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/3gvjz6/metadata.jsonld
@@ -1,0 +1,138 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/3gvjz6",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Material",
+        "rdfs:label": "carbon"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 10.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 30.0,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 270.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.121198,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "na-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 10.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 30.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 270.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.121198
+    }
+  ],
+  "schema:category": "na-ion",
+  "schema:identifier": [
+    "3gvjz6",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Hina"
+  },
+  "schema:model": "NaCR32140MP10",
+  "schema:name": "hina-nacr32140mp10-202410-3gvjz6",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250617__2C__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250618__2C__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250619__2C__15degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250620__2C__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/9peqy1/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/9peqy1/metadata.jsonld
@@ -1,0 +1,138 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/9peqy1",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Material",
+        "rdfs:label": "carbon"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 10.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 30.0,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 270.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.121198,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "na-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 10.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 30.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 270.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.121198
+    }
+  ],
+  "schema:category": "na-ion",
+  "schema:identifier": [
+    "9peqy1",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Hina"
+  },
+  "schema:model": "NaCR32140MP10",
+  "schema:name": "hina-nacr32140mp10-202410-9peqy1",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250609__C20__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250611__C20__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250612__C20__15degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250616__C20__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/e6yezv/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/e6yezv/metadata.jsonld
@@ -1,0 +1,132 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/e6yezv",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Material",
+        "rdfs:label": "carbon"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 10.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 30.0,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 270.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.121198,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "na-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 10.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 30.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 270.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.121198
+    }
+  ],
+  "schema:category": "na-ion",
+  "schema:identifier": [
+    "e6yezv",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Hina"
+  },
+  "schema:model": "NaCR32140MP10",
+  "schema:name": "hina-nacr32140mp10-202410-e6yezv",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250612__C50__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250623__GITT__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/metadata.jsonld
@@ -1,0 +1,2689 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "http://www.w3.org/ns/csvw"
+  ],
+  "@type": "schema:Dataset",
+  "schema:creator": [
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Clark",
+      "schema:givenName": "Simon",
+      "schema:name": "Simon Clark",
+      "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Guldahl",
+      "schema:givenName": "Julie Cathrine",
+      "schema:name": "Julie Cathrine Guldahl",
+      "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Tolchard",
+      "schema:givenName": "Julian",
+      "schema:name": "Julian Tolchard",
+      "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+    }
+  ],
+  "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery.",
+  "schema:hasPart": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250617__2C__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/3gvjz6"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250617__2C__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250617__2C__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250617__2C__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250617__2C__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250618__2C__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/3gvjz6"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250618__2C__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250618__2C__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250618__2C__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250618__2C__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250619__2C__15degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/3gvjz6"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250619__2C__15degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250619__2C__15degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250619__2C__15degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250619__2C__15degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250620__2C__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/3gvjz6"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250620__2C__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250620__2C__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250620__2C__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-3gvjz6__20250620__2C__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250609__C20__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/9peqy1"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250609__C20__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250609__C20__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-9peqy1__20250609__C20__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250609__C20__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250611__C20__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/9peqy1"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250611__C20__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250611__C20__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-9peqy1__20250611__C20__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250611__C20__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250612__C20__15degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/9peqy1"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250612__C20__15degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250612__C20__15degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-9peqy1__20250612__C20__15degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250612__C20__15degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250616__C20__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/9peqy1"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250616__C20__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250616__C20__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-9peqy1__20250616__C20__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-9peqy1__20250616__C20__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250612__C50__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/e6yezv"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250612__C50__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250612__C50__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-e6yezv__20250612__C50__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250612__C50__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250623__GITT__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/e6yezv"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: GITT.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250623__GITT__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250623__GITT__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-e6yezv__20250623__GITT__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-e6yezv__20250623__GITT__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "GITT",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - GITT",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250609__C50__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/mhpggp"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250609__C50__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250609__C50__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-mhpggp__20250609__C50__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250609__C50__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250625__C50__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/mhpggp"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250625__C50__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250625__C50__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-mhpggp__20250625__C50__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250625__C50__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250626__C50__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/mhpggp"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250626__C50__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250626__C50__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-mhpggp__20250626__C50__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250626__C50__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250710__C50__15degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/mhpggp"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250710__C50__15degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250710__C50__15degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-mhpggp__20250710__C50__15degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250710__C50__15degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250609__C20__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/r30yqg"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250609__C20__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250609__C20__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-r30yqg__20250609__C20__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250609__C20__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250611__C20__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/r30yqg"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250611__C20__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250611__C20__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-r30yqg__20250611__C20__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250611__C20__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250612__C20__15degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/r30yqg"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250612__C20__15degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250612__C20__15degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-r30yqg__20250612__C20__15degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250612__C20__15degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250616__C20__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/r30yqg"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250616__C20__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250616__C20__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-r30yqg__20250616__C20__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250616__C20__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250617__2C__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/v0pygf"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250617__2C__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250617__2C__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-v0pygf__20250617__2C__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250617__2C__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250618__2C__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/v0pygf"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250618__2C__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250618__2C__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-v0pygf__20250618__2C__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250618__2C__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250619__2C__15degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/v0pygf"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250619__2C__15degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250619__2C__15degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-v0pygf__20250619__2C__15degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250619__2C__15degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250620__2C__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/v0pygf"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250620__2C__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250620__2C__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-v0pygf__20250620__2C__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250620__2C__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250609__C20__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/wv5jgv"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250609__C20__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250609__C20__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250609__C20__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250609__C20__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250611__C20__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/wv5jgv"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250611__C20__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250611__C20__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250611__C20__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250611__C20__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250612__C20__15degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/wv5jgv"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250612__C20__15degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250612__C20__15degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250612__C20__15degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250612__C20__15degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250616__C20__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/wv5jgv"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C20.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250616__C20__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250616__C20__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250616__C20__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250616__C20__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C20",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C20",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250609__C50__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/z1nxja"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250609__C50__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250609__C50__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-z1nxja__20250609__C50__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250609__C50__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250625__C50__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/z1nxja"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250625__C50__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250625__C50__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-z1nxja__20250625__C50__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250625__C50__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250626__C50__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/z1nxja"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250626__C50__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250626__C50__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-z1nxja__20250626__C50__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250626__C50__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250710__C50__15degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/z1nxja"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: C50.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250710__C50__15degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250710__C50__15degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__hina-nacr32140mp10-202410-z1nxja__20250710__C50__15degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250710__C50__15degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C50",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - C50",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    }
+  ],
+  "schema:inLanguage": "en",
+  "schema:keywords": [
+    "li-ion",
+    "SLPBA842126HV",
+    "battery",
+    "ICP42/127/10",
+    "dcir",
+    "rate",
+    "thermal"
+  ],
+  "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+  "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data",
+  "schema:url": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410",
+  "schema:variableMeasured": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Test Time",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+      "schema:unitText": "s"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Voltage",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+      "schema:unitText": "V"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Current",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+      "schema:unitText": "A"
+    }
+  ],
+  "schema:version": "1.0.0"
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/mhpggp/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/mhpggp/metadata.jsonld
@@ -1,0 +1,138 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/mhpggp",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Material",
+        "rdfs:label": "carbon"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 10.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 30.0,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 270.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.121198,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "na-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 10.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 30.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 270.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.121198
+    }
+  ],
+  "schema:category": "na-ion",
+  "schema:identifier": [
+    "mhpggp",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Hina"
+  },
+  "schema:model": "NaCR32140MP10",
+  "schema:name": "hina-nacr32140mp10-202410-mhpggp",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250609__C50__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250625__C50__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250626__C50__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-mhpggp__20250710__C50__15degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/r30yqg/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/r30yqg/metadata.jsonld
@@ -1,0 +1,138 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/r30yqg",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Material",
+        "rdfs:label": "carbon"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 10.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 30.0,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 270.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.121198,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "na-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 10.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 30.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 270.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.121198
+    }
+  ],
+  "schema:category": "na-ion",
+  "schema:identifier": [
+    "r30yqg",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Hina"
+  },
+  "schema:model": "NaCR32140MP10",
+  "schema:name": "hina-nacr32140mp10-202410-r30yqg",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250609__C20__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250611__C20__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250612__C20__15degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-r30yqg__20250616__C20__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/v0pygf/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/v0pygf/metadata.jsonld
@@ -1,0 +1,138 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/v0pygf",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Material",
+        "rdfs:label": "carbon"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 10.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 30.0,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 270.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.121198,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "na-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 10.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 30.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 270.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.121198
+    }
+  ],
+  "schema:category": "na-ion",
+  "schema:identifier": [
+    "v0pygf",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Hina"
+  },
+  "schema:model": "NaCR32140MP10",
+  "schema:name": "hina-nacr32140mp10-202410-v0pygf",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250617__2C__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250618__2C__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250619__2C__15degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-v0pygf__20250620__2C__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/wv5jgv/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/wv5jgv/metadata.jsonld
@@ -1,0 +1,138 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/wv5jgv",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Material",
+        "rdfs:label": "carbon"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 10.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 30.0,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 270.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.121198,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "na-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 10.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 30.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 270.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.121198
+    }
+  ],
+  "schema:category": "na-ion",
+  "schema:identifier": [
+    "wv5jgv",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Hina"
+  },
+  "schema:model": "NaCR32140MP10",
+  "schema:name": "hina-nacr32140mp10-202410-wv5jgv",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250609__C20__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250611__C20__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250612__C20__15degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-wv5jgv__20250616__C20__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/hina/nacr32140-mp10/202410/z1nxja/metadata.jsonld
+++ b/examples/in/registry/hina/nacr32140-mp10/202410/z1nxja/metadata.jsonld
@@ -1,0 +1,138 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/hina/nacr32140mp10/202410/z1nxja",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Material",
+        "rdfs:label": "carbon"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 10.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 30.0,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 270.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.121198,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "na-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 10.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 30.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 270.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.121198
+    }
+  ],
+  "schema:category": "na-ion",
+  "schema:identifier": [
+    "z1nxja",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Hina"
+  },
+  "schema:model": "NaCR32140MP10",
+  "schema:name": "hina-nacr32140mp10-202410-z1nxja",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250609__C50__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250625__C50__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250626__C50__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__hina-nacr32140mp10-202410-z1nxja__20250710__C50__15degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/melasta/slpba842126hv/202410/aampje/metadata.jsonld
+++ b/examples/in/registry/melasta/slpba842126hv/202410/aampje/metadata.jsonld
@@ -1,0 +1,145 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/aampje",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumCobaltOxide",
+        "rdfs:label": "LithiumCobaltOxide"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 6.55,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 24.235,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 126,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.0544,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "pouch"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 6.55
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 24.235
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 126
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.0544
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "aampje",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Melasta"
+  },
+  "schema:model": "SLPBA842126HV",
+  "schema:name": "melasta-slpba842126hv-202410-aampje",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__35degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__45degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/melasta/slpba842126hv/202410/hqmg7h/metadata.jsonld
+++ b/examples/in/registry/melasta/slpba842126hv/202410/hqmg7h/metadata.jsonld
@@ -1,0 +1,148 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/hqmg7h",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumCobaltOxide",
+        "rdfs:label": "LithiumCobaltOxide"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 6.55,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 24.235,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 126,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.0544,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "pouch"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 6.55
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 24.235
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 126
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.0544
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "hqmg7h",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Melasta"
+  },
+  "schema:model": "SLPBA842126HV",
+  "schema:name": "melasta-slpba842126hv-202410-hqmg7h",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__35degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__Rate__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/melasta/slpba842126hv/202410/metadata.jsonld
+++ b/examples/in/registry/melasta/slpba842126hv/202410/metadata.jsonld
@@ -1,0 +1,1558 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "http://www.w3.org/ns/csvw"
+  ],
+  "@type": "schema:Dataset",
+  "schema:creator": [
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Clark",
+      "schema:givenName": "Simon",
+      "schema:name": "Simon Clark",
+      "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Guldahl",
+      "schema:givenName": "Julie Cathrine",
+      "schema:name": "Julie Cathrine Guldahl",
+      "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "SINTEF"
+      },
+      "schema:familyName": "Tolchard",
+      "schema:givenName": "Julian",
+      "schema:name": "Julian Tolchard",
+      "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+    }
+  ],
+  "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery.",
+  "schema:hasPart": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/aampje"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__35degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/aampje"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__35degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__35degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__35degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__35degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/aampje"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-aampje__20241011__DCIR__C10__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/hqmg7h"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__35degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/hqmg7h"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__35degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__35degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__35degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__35degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/hqmg7h"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__DCIR__C10__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__Rate__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/hqmg7h"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: Rate.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__Rate__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__Rate__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__Rate__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-hqmg7h__20241011__Rate__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Rate",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - Rate",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/p0jqc2"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__35degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/p0jqc2"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__35degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__35degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__35degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__35degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/p0jqc2"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/qv8zn1"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__35degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/qv8zn1"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__35degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__35degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__35degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__35degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/qv8zn1"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__Rate__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/qv8zn1"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: Rate.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__Rate__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__Rate__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__Rate__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__Rate__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Rate",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - Rate",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/tfscsy"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__25degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__35degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/tfscsy"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__35degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__35degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__35degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__35degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__45degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/tfscsy"
+      },
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Clark",
+          "schema:givenName": "Simon",
+          "schema:name": "Simon Clark",
+          "schema:sameAs": "https://orcid.org/0000-0002-8758-6109"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Guldahl",
+          "schema:givenName": "Julie Cathrine",
+          "schema:name": "Julie Cathrine Guldahl",
+          "schema:sameAs": "https://orcid.org/0009-0005-4059-7715"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "SINTEF"
+          },
+          "schema:familyName": "Tolchard",
+          "schema:givenName": "Julian",
+          "schema:name": "Julian Tolchard",
+          "schema:sameAs": "https://orcid.org/0000-0003-0934-4515"
+        }
+      ],
+      "schema:description": "Performance data for the Melasta SLPBA842126HV lithium-ion battery. Measurement technique: DCIR.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__45degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__45degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__45degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": "data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__45degC.bdf.parquet",
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "SLPBA842126HV",
+        "battery",
+        "ICP42/127/10",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DCIR",
+      "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data - DCIR",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    }
+  ],
+  "schema:inLanguage": "en",
+  "schema:keywords": [
+    "li-ion",
+    "SLPBA842126HV",
+    "battery",
+    "ICP42/127/10",
+    "dcir",
+    "rate",
+    "thermal"
+  ],
+  "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+  "schema:name": "Melasta SLPBA842126HV Lithium-Ion Cell Test Data",
+  "schema:url": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410",
+  "schema:variableMeasured": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Test Time",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+      "schema:unitText": "s"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Voltage",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+      "schema:unitText": "V"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Current",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+      "schema:unitText": "A"
+    }
+  ],
+  "schema:version": "1.0.0"
+}

--- a/examples/in/registry/melasta/slpba842126hv/202410/p0jqc2/metadata.jsonld
+++ b/examples/in/registry/melasta/slpba842126hv/202410/p0jqc2/metadata.jsonld
@@ -1,0 +1,145 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/p0jqc2",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumCobaltOxide",
+        "rdfs:label": "LithiumCobaltOxide"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 6.55,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 24.235,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 126,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.0544,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "pouch"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 6.55
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 24.235
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 126
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.0544
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "p0jqc2",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Melasta"
+  },
+  "schema:model": "SLPBA842126HV",
+  "schema:name": "melasta-slpba842126hv-202410-p0jqc2",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__35degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-p0jqc2__20241011__DCIR__C20__45degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/melasta/slpba842126hv/202410/qv8zn1/metadata.jsonld
+++ b/examples/in/registry/melasta/slpba842126hv/202410/qv8zn1/metadata.jsonld
@@ -1,0 +1,148 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/qv8zn1",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumCobaltOxide",
+        "rdfs:label": "LithiumCobaltOxide"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 6.55,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 24.235,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 126,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.0544,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "pouch"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 6.55
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 24.235
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 126
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.0544
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "qv8zn1",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Melasta"
+  },
+  "schema:model": "SLPBA842126HV",
+  "schema:name": "melasta-slpba842126hv-202410-qv8zn1",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__35degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__DCIR__C10__45degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-qv8zn1__20241011__Rate__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/melasta/slpba842126hv/202410/tfscsy/metadata.jsonld
+++ b/examples/in/registry/melasta/slpba842126hv/202410/tfscsy/metadata.jsonld
@@ -1,0 +1,145 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/melasta/slpba842126hv/202410/tfscsy",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumCobaltOxide",
+        "rdfs:label": "LithiumCobaltOxide"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 6.55,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 24.235,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 126,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.0544,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "ICP42/127/10"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "pouch"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 6.55
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 24.235
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 126
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.0544
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "tfscsy",
+    "ICP42/127/10"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Melasta"
+  },
+  "schema:model": "SLPBA842126HV",
+  "schema:name": "melasta-slpba842126hv-202410-tfscsy",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__35degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/melasta/slpba842126hv/202410/data/SINTEF__melasta-slpba842126hv-202410-tfscsy__20241011__DCIR__C20__45degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/panasonic/ncr18650pf/201707/metadata.jsonld
+++ b/examples/in/registry/panasonic/ncr18650pf/201707/metadata.jsonld
@@ -1,0 +1,14582 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "http://www.w3.org/ns/csvw"
+  ],
+  "@type": "schema:Dataset",
+  "schema:citation": [
+    "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+  ],
+  "schema:creator": [
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "University of Wisconsin Madison"
+      },
+      "schema:familyName": "Kollmeyer",
+      "schema:givenName": "Phillip",
+      "schema:name": "Phillip Kollmeyer",
+      "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+    }
+  ],
+  "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry.",
+  "schema:hasPart": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_1__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_1__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_1__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_1__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_1__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_REPEAT__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_REPEAT.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_REPEAT__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_REPEAT__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_REPEAT__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_REPEAT__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_REPEAT",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_REPEAT",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_1__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DISCHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_1__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_1__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_1__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_1__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DISCHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DISCHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_REPEAT__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DISCHARGE_1C_REPEAT.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_REPEAT__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_REPEAT__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_REPEAT__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_REPEAT__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DISCHARGE_1C_REPEAT",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DISCHARGE_1C_REPEAT",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__PAUSE_REPEAT__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_REPEAT.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__PAUSE_REPEAT__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__PAUSE_REPEAT__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170309__PAUSE_REPEAT__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__PAUSE_REPEAT__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_REPEAT",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_REPEAT",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170310__DISCHARGE_1C_2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DISCHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170310__DISCHARGE_1C_2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170310__DISCHARGE_1C_2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170310__DISCHARGE_1C_2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170310__DISCHARGE_1C_2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DISCHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DISCHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__CHARGE_1C_3__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__CHARGE_1C_3__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__CHARGE_1C_3__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170311__CHARGE_1C_3__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__CHARGE_1C_3__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_DISCHARGE_BETWEEN_PULSES__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_DISCHARGE_BETWEEN_PULSES.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_DISCHARGE_BETWEEN_PULSES__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_DISCHARGE_BETWEEN_PULSES__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_DISCHARGE_BETWEEN_PULSES__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_DISCHARGE_BETWEEN_PULSES__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_PULSES_C2_1C_2C_4C_6C__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_PULSES_C2_1C_2C_4C_6C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_PULSES_C2_1C_2C_4C_6C__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_PULSES_C2_1C_2C_4C_6C__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_PULSES_C2_1C_2C_4C_6C__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_PULSES_C2_1C_2C_4C_6C__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__TESTSEQ_TS003014__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: TESTSEQ_TS003014.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__TESTSEQ_TS003014__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__TESTSEQ_TS003014__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170311__TESTSEQ_TS003014__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__TESTSEQ_TS003014__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "TESTSEQ_TS003014",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - TESTSEQ_TS003014",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170312__CHARGE_1C_2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170312__CHARGE_1C_2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170312__CHARGE_1C_2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170312__CHARGE_1C_2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170312__CHARGE_1C_2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__CHARGE_1C_1__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__CHARGE_1C_1__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__CHARGE_1C_1__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170318__CHARGE_1C_1__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__CHARGE_1C_1__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__DRIVE_CYCLE_CYCLE1__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__DRIVE_CYCLE_CYCLE1__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__DRIVE_CYCLE_CYCLE1__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170318__DRIVE_CYCLE_CYCLE1__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__DRIVE_CYCLE_CYCLE1__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__PAUSE_1__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__PAUSE_1__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__PAUSE_1__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170318__PAUSE_1__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__PAUSE_1__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_3__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_3__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_3__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_3__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_3__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_4__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_4__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_4__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_4__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_4__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE3__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE3__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE3__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE3__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE3__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE4__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE4__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE4__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE4__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE4__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_3__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_3__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_3__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_3__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_3__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_4__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_4__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_4__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_4__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_4__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_1__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_1__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_1__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_1__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_1__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2_DUP2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2_DUP2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2_DUP2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2_DUP2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2_DUP2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2_DUP2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2_DUP2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2_DUP2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_A__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_HWFET_A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_A__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_A__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_A__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_A__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_HWFET_A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_HWFET_A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_B__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_HWFET_B.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_B__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_B__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_B__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_B__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_HWFET_B",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_HWFET_B",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_US06__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_US06.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_US06__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_US06__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_US06__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_US06__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_US06",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_US06",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_1__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_1__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_1__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_1__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_1__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2_DUP2__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_2_DUP2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2_DUP2__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2_DUP2__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2_DUP2__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2_DUP2__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_2_DUP2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_2_DUP2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_3__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_3__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_3__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_3__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_3__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_3__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_3__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_3__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_3__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_3__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_4__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_4__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_4__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_4__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_4__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_5__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_5__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_5__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_5__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_5__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_LA92__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_LA92.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_LA92__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_LA92__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_LA92__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_LA92__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_LA92",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_LA92",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_NN__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_NN.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_NN__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_NN__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_NN__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_NN__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_NN",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_NN",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_UDDS__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_UDDS.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_UDDS__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_UDDS__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_UDDS__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_UDDS__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_UDDS",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_UDDS",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_4__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_4__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_4__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_4__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_4__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_5__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_5__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_5__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_5__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_5__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_HWFET__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_HWFET.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_HWFET__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_HWFET__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_HWFET__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_HWFET__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_HWFET",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_HWFET",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_LA92__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_LA92.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_LA92__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_LA92__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_LA92__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_LA92__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_LA92",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_LA92",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_NN__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_NN.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_NN__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_NN__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_NN__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_NN__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_NN",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_NN",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_UDDS__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_UDDS.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_UDDS__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_UDDS__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_UDDS__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_UDDS__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_UDDS",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_UDDS",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_US06__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_US06.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_US06__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_US06__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_US06__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_US06__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_US06",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_US06",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_DISCHARGE_BETWEEN_PULSES.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_PULSES_C2_1C_2C_4C_6C__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_PULSES_C2_1C_2C_4C_6C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_PULSES_C2_1C_2C_4C_6C__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_PULSES_C2_1C_2C_4C_6C__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_PULSES_C2_1C_2C_4C_6C__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_PULSES_C2_1C_2C_4C_6C__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1_DBD0F3__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1_DBD0F3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1_DBD0F3__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1_DBD0F3__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1_DBD0F3__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1_DBD0F3__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1_DBD0F3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1_DBD0F3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_2A__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_2A__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_2A__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_2A__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_2A__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE1__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE1__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE1__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE1__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE1__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE2__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE2__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE2__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE2__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE2__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_1__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_1__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_1__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_1__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_1__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_2__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_2__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_2__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_2__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_2__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_2__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_2__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_2__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_2__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_2__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_3__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_3__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_3__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_3__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_3__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE3__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE3__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE3__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE3__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE3__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE4__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE4__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE4__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE4__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE4__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_3__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_3__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_3__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_3__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_3__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_4__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_4__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_4__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_4__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_4__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__CHARGE_1C_4__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__CHARGE_1C_4__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__CHARGE_1C_4__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170406__CHARGE_1C_4__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__CHARGE_1C_4__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__PAUSE_5__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__PAUSE_5__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__PAUSE_5__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170406__PAUSE_5__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__PAUSE_5__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__CHARGE_1C_1A__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__CHARGE_1C_1A__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__CHARGE_1C_1A__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170427__CHARGE_1C_1A__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__CHARGE_1C_1A__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_DISCHARGE_BETWEEN_PULSES.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170427__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170429__CHARGE_1C_2A__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170429__CHARGE_1C_2A__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170429__CHARGE_1C_2A__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170429__CHARGE_1C_2A__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170429__CHARGE_1C_2A__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170508__OCV_C20_END_OF_TESTS__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: OCV_C20_END_OF_TESTS.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170508__OCV_C20_END_OF_TESTS__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170508__OCV_C20_END_OF_TESTS__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170508__OCV_C20_END_OF_TESTS__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170508__OCV_C20_END_OF_TESTS__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "OCV_C20_END_OF_TESTS",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - OCV_C20_END_OF_TESTS",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__DISCHARGE_PULSE__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DISCHARGE_PULSE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__DISCHARGE_PULSE__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__DISCHARGE_PULSE__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170520__DISCHARGE_PULSE__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__DISCHARGE_PULSE__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DISCHARGE_PULSE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DISCHARGE_PULSE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES_4995DA__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_DISCHARGE_BETWEEN_PULSES_4995DA.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES_4995DA__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES_4995DA__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES_4995DA__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES_4995DA__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_DISCHARGE_BETWEEN_PULSES_4995DA",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_DISCHARGE_BETWEEN_PULSES_4995DA",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_DISCHARGE_BETWEEN_PULSES.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_PULSES_C2_1C_2C_4C_6C__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_PULSES_C2_1C_2C_4C_6C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_PULSES_C2_1C_2C_4C_6C__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_PULSES_C2_1C_2C_4C_6C__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_PULSES_C2_1C_2C_4C_6C__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_PULSES_C2_1C_2C_4C_6C__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__PRECHARGE__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PRECHARGE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__PRECHARGE__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__PRECHARGE__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170520__PRECHARGE__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__PRECHARGE__25degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PRECHARGE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PRECHARGE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170521__CHARGE_1C_2A__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170521__CHARGE_1C_2A__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170521__CHARGE_1C_2A__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170521__CHARGE_1C_2A__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170521__CHARGE_1C_2A__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170522__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_DISCHARGE_BETWEEN_PULSES.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170522__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170522__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170522__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170522__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170526__CHARGE_1C_2A__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170526__CHARGE_1C_2A__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170526__CHARGE_1C_2A__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170526__CHARGE_1C_2A__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170526__CHARGE_1C_2A__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_1__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_1__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_1__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_1__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_1__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_2A__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_2A__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_2A__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_2A__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_2A__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE1__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE1__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE1__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE1__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE1__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE2__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE2__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE2__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE2__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE2__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_2__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_2__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_2__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_2__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_2__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_3__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_3__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_3__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_3__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_3__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_COMBINED_LA92_NN__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_COMBINED_LA92_NN.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_COMBINED_LA92_NN__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_COMBINED_LA92_NN__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_COMBINED_LA92_NN__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_COMBINED_LA92_NN__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_COMBINED_LA92_NN",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_COMBINED_LA92_NN",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE3__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE3__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE3__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE3__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE3__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE4__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE4__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE4__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE4__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE4__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_LA92__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_LA92.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_LA92__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_LA92__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_LA92__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_LA92__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_LA92",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_LA92",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_NN__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_NN.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_NN__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_NN__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_NN__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_NN__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_NN",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_NN",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_3__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_3__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_3__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_3__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_3__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_4__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_4__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_4__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_4__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_4__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_4__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_4__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_4__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_4__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_4__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_5__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_5__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_5__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_5__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_5__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_6__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_6.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_6__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_6__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_6__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_6__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_6",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_6",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_7__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_7.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_7__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_7__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_7__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_7__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_7",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_7",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_HWFET__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_HWFET.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_HWFET__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_HWFET__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_HWFET__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_HWFET__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_HWFET",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_HWFET",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_UDDS__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_UDDS.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_UDDS__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_UDDS__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_UDDS__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_UDDS__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_UDDS",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_UDDS",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_US06__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_US06.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_US06__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_US06__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_US06__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_US06__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_US06",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_US06",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_5__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_5__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_5__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_5__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_5__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_6__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_6.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_6__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_6__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_6__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_6__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_6",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_6",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_7__0degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_7.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_7__0degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_7__0degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_7__0degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_7__0degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_7",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_7",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_HWFET__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_HWFET.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_HWFET__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_HWFET__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_HWFET__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_HWFET__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_HWFET",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_HWFET",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_LA92__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_LA92.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_LA92__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_LA92__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_LA92__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_LA92__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_LA92",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_LA92",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_UDDS__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_UDDS.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_UDDS__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_UDDS__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_UDDS__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_UDDS__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_UDDS",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_UDDS",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_US06__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_US06.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_US06__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_US06__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_US06__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_US06__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_US06",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_US06",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_DISCHARGE_BETWEEN_PULSES__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_DISCHARGE_BETWEEN_PULSES.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_DISCHARGE_BETWEEN_PULSES__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_DISCHARGE_BETWEEN_PULSES__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_DISCHARGE_BETWEEN_PULSES__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_DISCHARGE_BETWEEN_PULSES__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_PULSES_C2_1C_2C_4C_6C__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_PULSES_C2_1C_2C_4C_6C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_PULSES_C2_1C_2C_4C_6C__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_PULSES_C2_1C_2C_4C_6C__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_PULSES_C2_1C_2C_4C_6C__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_PULSES_C2_1C_2C_4C_6C__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__PRECHARGE__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PRECHARGE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__PRECHARGE__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__PRECHARGE__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170607__PRECHARGE__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__PRECHARGE__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PRECHARGE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PRECHARGE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170608__CHARGE_1C_1A__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170608__CHARGE_1C_1A__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170608__CHARGE_1C_1A__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170608__CHARGE_1C_1A__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170608__CHARGE_1C_1A__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_1__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_1__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_1__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_1__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_1__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2A__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2A__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2A__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2A__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2A__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE1__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE1__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE1__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE1__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE1__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE2__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE2__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE2__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE2__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE2__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_1__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_1__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_1__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_1__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_1__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_2__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_2__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_2__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_2__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_2__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_3__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_3__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_3__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_3__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_3__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__CHARGE_1C_3__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__CHARGE_1C_3__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__CHARGE_1C_3__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170611__CHARGE_1C_3__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__CHARGE_1C_3__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE3__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE3__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE3__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE3__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE3__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE4__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE4__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE4__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE4__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE4__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__PAUSE_4__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__PAUSE_4__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__PAUSE_4__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170611__PAUSE_4__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__PAUSE_4__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_8__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_8.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_8__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_8__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_8__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_8__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_8",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_8",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_9__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_9.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_9__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_9__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_9__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_9__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_9",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_9",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__DRIVE_CYCLE_NN__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_NN.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__DRIVE_CYCLE_NN__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__DRIVE_CYCLE_NN__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170614__DRIVE_CYCLE_NN__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__DRIVE_CYCLE_NN__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_NN",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_NN",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__PAUSE_9__-10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_9.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__PAUSE_9__-10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__PAUSE_9__-10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170614__PAUSE_9__-10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__PAUSE_9__-10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_9",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_9",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_DISCHARGE_BETWEEN_PULSES__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_DISCHARGE_BETWEEN_PULSES.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_DISCHARGE_BETWEEN_PULSES__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_DISCHARGE_BETWEEN_PULSES__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_DISCHARGE_BETWEEN_PULSES__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_DISCHARGE_BETWEEN_PULSES__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_DISCHARGE_BETWEEN_PULSES",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_PULSES_C2_1C_2C_4C_6C__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: HPPC_PULSES_C2_1C_2C_4C_6C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_PULSES_C2_1C_2C_4C_6C__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_PULSES_C2_1C_2C_4C_6C__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_PULSES_C2_1C_2C_4C_6C__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_PULSES_C2_1C_2C_4C_6C__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - HPPC_PULSES_C2_1C_2C_4C_6C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__CHARGE_1C_2A__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2A.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__CHARGE_1C_2A__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__CHARGE_1C_2A__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170623__CHARGE_1C_2A__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__CHARGE_1C_2A__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2A",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2A",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_HWFET__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_HWFET.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_HWFET__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_HWFET__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_HWFET__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_HWFET__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_HWFET",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_HWFET",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_LA92__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_LA92.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_LA92__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_LA92__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_LA92__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_LA92__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_LA92",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_LA92",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_NN__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_NN.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_NN__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_NN__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_NN__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_NN__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_NN",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_NN",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_UDDS__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_UDDS.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_UDDS__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_UDDS__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_UDDS__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_UDDS__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_UDDS",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_UDDS",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_1__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_1__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_1__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_1__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_1__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_2__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_2__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_2__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_2__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_2__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_3__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_3__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_3__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_3__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_3__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE1__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE1__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE1__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE1__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE1__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE2__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE2__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE2__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE2__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE2__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE3__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE3__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE3__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE3__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE3__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_1__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_1__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_1__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_1__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_1__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_2__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_2__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_2__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_2__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_2__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_3__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_3__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_3__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_3__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_3__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_4__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_4__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_4__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_4__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_4__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_5__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_5__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_5__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_5__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_5__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_CYCLE4__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_CYCLE4__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_CYCLE4__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_CYCLE4__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_CYCLE4__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_US06__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_US06.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_US06__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_US06__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_US06__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_US06__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_US06",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_US06",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_4__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_4__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_4__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_4__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_4__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_5__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_5__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_5__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_5__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_5__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__CHARGE_1C_1__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__CHARGE_1C_1__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__CHARGE_1C_1__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170630__CHARGE_1C_1__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__CHARGE_1C_1__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_CYCLE1_TRISE__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_CYCLE1_TRISE__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_CYCLE1_TRISE__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_CYCLE1_TRISE__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_CYCLE1_TRISE__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_1__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_1__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_1__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_1__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_1__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_2__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_2__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_2__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_2__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_2__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PRECHARGE__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PRECHARGE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PRECHARGE__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PRECHARGE__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170630__PRECHARGE__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PRECHARGE__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PRECHARGE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PRECHARGE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_2__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_2__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_2__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_2__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_2__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_3__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_3__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_3__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_3__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_3__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_4__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_4__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_4__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_4__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_4__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_5__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_5__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_5__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_5__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_5__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE2_TRISE__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE2_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE2_TRISE__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE2_TRISE__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE2_TRISE__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE2_TRISE__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE2_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE2_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE3_TRISE__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE3_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE3_TRISE__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE3_TRISE__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE3_TRISE__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE3_TRISE__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE3_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE3_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE4_TRISE__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE4_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE4_TRISE__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE4_TRISE__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE4_TRISE__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE4_TRISE__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE4_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE4_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_US06_TRISE__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_US06_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_US06_TRISE__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_US06_TRISE__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_US06_TRISE__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_US06_TRISE__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_US06_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_US06_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_3__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_3__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_3__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_3__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_3__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_4__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_4__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_4__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_4__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_4__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_5__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_5__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_5__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_5__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_5__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170704__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__-20degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170704__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__-20degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170704__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__-20degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170704__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__-20degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170704__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__-20degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__CHARGE_1C_1__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__CHARGE_1C_1__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__CHARGE_1C_1__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170709__CHARGE_1C_1__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__CHARGE_1C_1__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_CYCLE1_TRISE__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_CYCLE1_TRISE__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_CYCLE1_TRISE__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_CYCLE1_TRISE__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_CYCLE1_TRISE__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_1__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_1__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_1__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_1__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_1__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_2__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_2__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_2__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_2__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_2__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PRECHARGE__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PRECHARGE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PRECHARGE__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PRECHARGE__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170709__PRECHARGE__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PRECHARGE__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PRECHARGE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PRECHARGE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_2__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_2__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_2__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_2__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_2__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_3__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_3__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_3__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_3__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_3__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_4__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_4__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_4__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_4__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_4__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_5__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_5__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_5__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_5__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_5__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE2_TRISE__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE2_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE2_TRISE__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE2_TRISE__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE2_TRISE__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE2_TRISE__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE2_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE2_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE3_TRISE__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE3_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE3_TRISE__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE3_TRISE__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE3_TRISE__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE3_TRISE__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE3_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE3_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE4_TRISE__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE4_TRISE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE4_TRISE__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE4_TRISE__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE4_TRISE__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE4_TRISE__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE4_TRISE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE4_TRISE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_3__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_3__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_3__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_3__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_3__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_4__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_4.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_4__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_4__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_4__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_4__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_4",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_4",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_5__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_5.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_5__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_5__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_5__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_5__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_5",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_5",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170719__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170719__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170719__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170719__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170719__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_1__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_1__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_1__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_1__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_1__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_2__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_2__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_2__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_2__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_2__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__DISCHARGE_1C_1__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DISCHARGE_1C_1.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__DISCHARGE_1C_1__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__DISCHARGE_1C_1__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170722__DISCHARGE_1C_1__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__DISCHARGE_1C_1__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DISCHARGE_1C_1",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DISCHARGE_1C_1",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__CHARGE_1C_REPEAT__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_REPEAT.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__CHARGE_1C_REPEAT__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__CHARGE_1C_REPEAT__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170723__CHARGE_1C_REPEAT__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__CHARGE_1C_REPEAT__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_REPEAT",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_REPEAT",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__DISCHARGE_1C_REPEAT__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DISCHARGE_1C_REPEAT.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__DISCHARGE_1C_REPEAT__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__DISCHARGE_1C_REPEAT__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170723__DISCHARGE_1C_REPEAT__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__DISCHARGE_1C_REPEAT__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DISCHARGE_1C_REPEAT",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DISCHARGE_1C_REPEAT",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__PAUSE_REPEAT__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: PAUSE_REPEAT.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__PAUSE_REPEAT__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__PAUSE_REPEAT__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170723__PAUSE_REPEAT__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__PAUSE_REPEAT__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "PAUSE_REPEAT",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - PAUSE_REPEAT",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__CHARGE_1C_3__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: CHARGE_1C_3.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__CHARGE_1C_3__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__CHARGE_1C_3__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170724__CHARGE_1C_3__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__CHARGE_1C_3__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "CHARGE_1C_3",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - CHARGE_1C_3",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__DISCHARGE_1C_2__10degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8"
+      },
+      "schema:citation": [
+        "Phillip Kollmeyer (2018) Panasonic 18650PF Li-ion Battery Data, Mendeley Data, V1, doi: 10.17632/wykht8y7tg.1"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Wisconsin Madison"
+          },
+          "schema:familyName": "Kollmeyer",
+          "schema:givenName": "Phillip",
+          "schema:name": "Phillip Kollmeyer",
+          "schema:sameAs": "https://orcid.org/0000-0003-3576-672X"
+        }
+      ],
+      "schema:description": "Raw data from the Mendeley Data dataset by Phillip Kollmeyer (doi: 10.17632/wykht8y7tg.1) curated for integration into the BDF registry. Measurement technique: DISCHARGE_1C_2.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__DISCHARGE_1C_2__10degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__DISCHARGE_1C_2__10degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UW__panasonic-ncr18650pf-201707-wykht8__20170724__DISCHARGE_1C_2__10degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__DISCHARGE_1C_2__10degC.bdf.parquet",
+        "10.17632/wykht8y7tg.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "ncr18650pf",
+        "panasonic",
+        "battery",
+        "hppc",
+        "eis",
+        "drive-cycle",
+        "ocv",
+        "kalman-filtering",
+        "neural-networks",
+        "nca",
+        "graphite"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "DISCHARGE_1C_2",
+      "schema:name": "Panasonic NCR18650PF Li-ion Battery Data - DISCHARGE_1C_2",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    }
+  ],
+  "schema:identifier": "10.17632/wykht8y7tg.1",
+  "schema:inLanguage": "en",
+  "schema:keywords": [
+    "li-ion",
+    "ncr18650pf",
+    "panasonic",
+    "battery",
+    "hppc",
+    "eis",
+    "drive-cycle",
+    "ocv",
+    "kalman-filtering",
+    "neural-networks",
+    "nca",
+    "graphite"
+  ],
+  "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+  "schema:name": "Panasonic NCR18650PF Li-ion Battery Data",
+  "schema:url": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707",
+  "schema:variableMeasured": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Test Time",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+      "schema:unitText": "s"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Voltage",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+      "schema:unitText": "V"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Current",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+      "schema:unitText": "A"
+    }
+  ],
+  "schema:version": "1.0.0"
+}

--- a/examples/in/registry/panasonic/ncr18650pf/201707/wykht8/metadata.jsonld
+++ b/examples/in/registry/panasonic/ncr18650pf/201707/wykht8/metadata.jsonld
@@ -1,0 +1,709 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/panasonic/ncr18650pf/201707/wykht8",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelCobaltAluminiumOxide",
+        "rdfs:label": "LithiumNickelCobaltAluminiumOxide"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.6,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 2.9,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 9.9,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 47.5,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.0165,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR18/650"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.6
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 2.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 9.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 47.5
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.0165
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "wykht8",
+    "INR18/650"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Panasonic"
+  },
+  "schema:model": "NCR18650PF",
+  "schema:name": "panasonic-ncr18650pf-201707-wykht8",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_1__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__CHARGE_1C_REPEAT__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_1__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__DISCHARGE_1C_REPEAT__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170309__PAUSE_REPEAT__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170310__DISCHARGE_1C_2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__CHARGE_1C_3__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_DISCHARGE_BETWEEN_PULSES__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__HPPC_PULSES_C2_1C_2C_4C_6C__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170311__TESTSEQ_TS003014__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170312__CHARGE_1C_2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__CHARGE_1C_1__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__DRIVE_CYCLE_CYCLE1__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170318__PAUSE_1__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_3__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__CHARGE_1C_4__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE3__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__DRIVE_CYCLE_CYCLE4__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_3__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170319__PAUSE_4__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_1__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__CHARGE_1C_2_DUP2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_A__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_HWFET_B__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__DRIVE_CYCLE_US06__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_1__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_2_DUP2__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170320__PAUSE_3__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_3__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_4__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__CHARGE_1C_5__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_LA92__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_NN__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__DRIVE_CYCLE_UDDS__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_4__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170321__PAUSE_5__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92_NN__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_HWFET__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_LA92__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_NN__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_UDDS__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__DRIVE_CYCLE_US06__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170327__HPPC_PULSES_C2_1C_2C_4C_6C__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_1_DBD0F3__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__CHARGE_1C_2A__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE1__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__DRIVE_CYCLE_CYCLE2__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_1__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170328__PAUSE_2__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_2__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__CHARGE_1C_3__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE3__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__DRIVE_CYCLE_CYCLE4__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_3__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170405__PAUSE_4__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__CHARGE_1C_4__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170406__PAUSE_5__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__CHARGE_1C_1A__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170427__HPPC_DISCHARGE_BETWEEN_PULSES__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170429__CHARGE_1C_2A__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170508__OCV_C20_END_OF_TESTS__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__DISCHARGE_PULSE__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES_4995DA__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__HPPC_PULSES_C2_1C_2C_4C_6C__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170520__PRECHARGE__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170521__CHARGE_1C_2A__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170522__HPPC_DISCHARGE_BETWEEN_PULSES__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170526__CHARGE_1C_2A__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_1__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__CHARGE_1C_2A__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE1__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170530__DRIVE_CYCLE_CYCLE2__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_2__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__CHARGE_1C_3__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_COMBINED_LA92_NN__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE3__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_CYCLE4__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_LA92__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__DRIVE_CYCLE_NN__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_3__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170601__PAUSE_4__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_4__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_5__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_6__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__CHARGE_1C_7__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_HWFET__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_UDDS__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__DRIVE_CYCLE_US06__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_5__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_6__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170602__PAUSE_7__0degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_COMBINED_US06_HWFET_UDDS_LA92__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_HWFET__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_LA92__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_UDDS__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__DRIVE_CYCLE_US06__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_DISCHARGE_BETWEEN_PULSES__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__HPPC_PULSES_C2_1C_2C_4C_6C__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170607__PRECHARGE__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170608__CHARGE_1C_1A__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_1__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__CHARGE_1C_2A__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE1__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__DRIVE_CYCLE_CYCLE2__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_1__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_2__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170610__PAUSE_3__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__CHARGE_1C_3__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE3__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__DRIVE_CYCLE_CYCLE4__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170611__PAUSE_4__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_8__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__CHARGE_1C_9__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__DRIVE_CYCLE_NN__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170614__PAUSE_9__-10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_DISCHARGE_BETWEEN_PULSES__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170615__HPPC_PULSES_C2_1C_2C_4C_6C__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__CHARGE_1C_2A__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_HWFET__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_LA92__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_NN__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170623__DRIVE_CYCLE_UDDS__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_1__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_2__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__CHARGE_1C_3__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE1__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE2__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__DRIVE_CYCLE_CYCLE3__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_1__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_2__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170624__PAUSE_3__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_4__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__CHARGE_1C_5__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_CYCLE4__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__DRIVE_CYCLE_US06__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_4__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170625__PAUSE_5__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__CHARGE_1C_1__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__DRIVE_CYCLE_CYCLE1_TRISE__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_1__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PAUSE_2__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170630__PRECHARGE__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_2__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_3__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_4__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__CHARGE_1C_5__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE2_TRISE__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE3_TRISE__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_CYCLE4_TRISE__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__DRIVE_CYCLE_US06_TRISE__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_3__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_4__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170701__PAUSE_5__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170704__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__-20degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__CHARGE_1C_1__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_COMBINED_HWFET_UDDS_LA92_NN_TRISE__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__DRIVE_CYCLE_CYCLE1_TRISE__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_1__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PAUSE_2__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170709__PRECHARGE__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_2__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_3__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_4__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__CHARGE_1C_5__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE2_TRISE__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE3_TRISE__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__DRIVE_CYCLE_CYCLE4_TRISE__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_3__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_4__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170710__PAUSE_5__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170719__DRIVE_CYCLE_CYCLE1TO4_TRISE_PAUSE__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_1__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__CHARGE_1C_2__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170722__DISCHARGE_1C_1__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__CHARGE_1C_REPEAT__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__DISCHARGE_1C_REPEAT__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170723__PAUSE_REPEAT__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__CHARGE_1C_3__10degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/panasonic/ncr18650pf/201707/data/UW__panasonic-ncr18650pf-201707-wykht8__20170724__DISCHARGE_1C_2__10degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/samsung/inr2170030t/2022/C1202/metadata.jsonld
+++ b/examples/in/registry/samsung/inr2170030t/2022/C1202/metadata.jsonld
@@ -1,0 +1,139 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/samsung/inr2170030t/2022/c1202",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.6,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 3.0,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 10.8,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 69.0,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.024,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR21/700"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.6
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 3.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 10.8
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 69.0
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.024
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "C1202",
+    "INR21/700"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Samsung"
+  },
+  "schema:model": "INR2170030T",
+  "schema:name": "samsung-inr2170030t-2022-c1202",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/samsung/inr2170030t/2022/data/UniversityofWindsor__samsung-inr2170030t-2022-c1202__2022__C30__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/samsung/inr2170030t/2022/metadata.jsonld
+++ b/examples/in/registry/samsung/inr2170030t/2022/metadata.jsonld
@@ -1,0 +1,218 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "http://www.w3.org/ns/csvw"
+  ],
+  "@type": "schema:Dataset",
+  "schema:citation": "Sundaresan, Sneha; Devabattini, Bharath C.; Kumar, Pradeep; Pattipati, Krishna; Balasingam, Balakumar (2022), \u201cDataset for Tabular OCV modeling\u201d, Mendeley Data, V1, doi: 10.17632/m9w7grpjc7.1",
+  "schema:creator": [
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "University of Windsor"
+      },
+      "schema:familyName": "Sundaresan",
+      "schema:givenName": "Sneha",
+      "schema:name": "Sneha Sundaresan",
+      "schema:sameAs": "https://orcid.org/0000-0001-7471-440X"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "University of Windsor"
+      },
+      "schema:familyName": "Devabattini",
+      "schema:givenName": "Bharath C.",
+      "schema:name": "Bharath C. Devabattini"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "University of Windsor"
+      },
+      "schema:familyName": "Kumar",
+      "schema:givenName": "Pradeep",
+      "schema:name": "Pradeep Kumar"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "University of Windsor"
+      },
+      "schema:familyName": "Pattipati",
+      "schema:givenName": "Krishna",
+      "schema:name": "Krishna Pattipati"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "University of Windsor"
+      },
+      "schema:familyName": "Balasingam",
+      "schema:givenName": "Balakumar",
+      "schema:name": "Balakumar Balasingam"
+    }
+  ],
+  "schema:description": "Battery terminal voltage and current recorded during the OCV-SOC characterization process of a Li-ion Samsung 30T-INR21700 cell. Includes Arbin cycler data and a reproducible CC-CV charge and C/30 discharge/charge OCV test procedure for developing OCV-SOC models and tabular OCV representations.",
+  "schema:hasPart": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/samsung/inr2170030t/2022/data/UniversityofWindsor__samsung-inr2170030t-2022-c1202__2022__C30__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/samsung/inr2170030t/2022/c1202"
+      },
+      "schema:citation": "Sundaresan, Sneha; Devabattini, Bharath C.; Kumar, Pradeep; Pattipati, Krishna; Balasingam, Balakumar (2022), \u201cDataset for Tabular OCV modeling\u201d, Mendeley Data, V1, doi: 10.17632/m9w7grpjc7.1",
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Windsor"
+          },
+          "schema:familyName": "Sundaresan",
+          "schema:givenName": "Sneha",
+          "schema:name": "Sneha Sundaresan",
+          "schema:sameAs": "https://orcid.org/0000-0001-7471-440X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Windsor"
+          },
+          "schema:familyName": "Devabattini",
+          "schema:givenName": "Bharath C.",
+          "schema:name": "Bharath C. Devabattini"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Windsor"
+          },
+          "schema:familyName": "Kumar",
+          "schema:givenName": "Pradeep",
+          "schema:name": "Pradeep Kumar"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Windsor"
+          },
+          "schema:familyName": "Pattipati",
+          "schema:givenName": "Krishna",
+          "schema:name": "Krishna Pattipati"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "University of Windsor"
+          },
+          "schema:familyName": "Balasingam",
+          "schema:givenName": "Balakumar",
+          "schema:name": "Balakumar Balasingam"
+        }
+      ],
+      "schema:description": "Battery terminal voltage and current recorded during the OCV-SOC characterization process of a Li-ion Samsung 30T-INR21700 cell. Includes Arbin cycler data and a reproducible CC-CV charge and C/30 discharge/charge OCV test procedure for developing OCV-SOC models and tabular OCV representations. Measurement technique: C30.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/samsung/inr2170030t/2022/data/UniversityofWindsor__samsung-inr2170030t-2022-c1202__2022__C30__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/samsung/inr2170030t/2022/data/UniversityofWindsor__samsung-inr2170030t-2022-c1202__2022__C30__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "UniversityofWindsor__samsung-inr2170030t-2022-c1202__2022__C30__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/UniversityofWindsor__samsung-inr2170030t-2022-c1202__2022__C30__25degC.bdf.parquet",
+        "10.17632/m9w7grpjc7.1"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "battery management system",
+        "lithium ion battery",
+        "state-of-charge",
+        "ocv-soc",
+        "open-circuit voltage",
+        "samsung",
+        "30t",
+        "inr21700-30t",
+        "arbin",
+        "c/30",
+        "25degc",
+        "tabular ocv"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "C30",
+      "schema:name": "Dataset for Tabular OCV modeling - C30",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    }
+  ],
+  "schema:identifier": "10.17632/m9w7grpjc7.1",
+  "schema:inLanguage": "en",
+  "schema:keywords": [
+    "battery management system",
+    "lithium ion battery",
+    "state-of-charge",
+    "ocv-soc",
+    "open-circuit voltage",
+    "samsung",
+    "30t",
+    "inr21700-30t",
+    "arbin",
+    "c/30",
+    "25degc",
+    "tabular ocv"
+  ],
+  "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+  "schema:name": "Dataset for Tabular OCV modeling",
+  "schema:url": "https://github.com/digibatt/battery-data/samsung/inr2170030t/2022",
+  "schema:variableMeasured": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Test Time",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+      "schema:unitText": "s"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Voltage",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+      "schema:unitText": "V"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Current",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+      "schema:unitText": "A"
+    }
+  ],
+  "schema:version": "1.0.0"
+}

--- a/examples/in/registry/tesla/inr46800/2022/083828/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/083828/metadata.jsonld
@@ -1,0 +1,134 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/083828",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide811",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide811"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 22.078,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 82.75,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 355.9,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.036,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR46/800"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 22.078
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 82.75
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 355.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.036
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "083828",
+    "INR46/800"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Tesla"
+  },
+  "schema:model": "INR46800",
+  "schema:name": "tesla-inr46800-2022-083828"
+}

--- a/examples/in/registry/tesla/inr46800/2022/131828/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/131828/metadata.jsonld
@@ -1,0 +1,139 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/131828",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide811",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide811"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 22.078,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 82.75,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 355.9,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.036,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR46/800"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 22.078
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 82.75
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 355.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.036
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "131828",
+    "INR46/800"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Tesla"
+  },
+  "schema:model": "INR46800",
+  "schema:name": "tesla-inr46800-2022-131828",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-131828__2022__Capacity__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/tesla/inr46800/2022/186828/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/186828/metadata.jsonld
@@ -1,0 +1,139 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/186828",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide811",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide811"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 22.078,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 82.75,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 355.9,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.036,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR46/800"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 22.078
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 82.75
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 355.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.036
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "186828",
+    "INR46/800"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Tesla"
+  },
+  "schema:model": "INR46800",
+  "schema:name": "tesla-inr46800-2022-186828",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-186828__2022__Capacity__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/tesla/inr46800/2022/444828/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/444828/metadata.jsonld
@@ -1,0 +1,139 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/444828",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide811",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide811"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 22.078,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 82.75,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 355.9,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.036,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR46/800"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 22.078
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 82.75
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 355.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.036
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "444828",
+    "INR46/800"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Tesla"
+  },
+  "schema:model": "INR46800",
+  "schema:name": "tesla-inr46800-2022-444828",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-444828__2022__Capacity__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/tesla/inr46800/2022/536828/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/536828/metadata.jsonld
@@ -1,0 +1,142 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/536828",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide811",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide811"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 22.078,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 82.75,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 355.9,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.036,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR46/800"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 22.078
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 82.75
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 355.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.036
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "536828",
+    "INR46/800"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Tesla"
+  },
+  "schema:model": "INR46800",
+  "schema:name": "tesla-inr46800-2022-536828",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-536828__2022__2C__25degC.bdf.parquet#dataset"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-536828__2022__Capacity__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/tesla/inr46800/2022/549828/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/549828/metadata.jsonld
@@ -1,0 +1,139 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/549828",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide811",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide811"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 22.078,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 82.75,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 355.9,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.036,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR46/800"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 22.078
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 82.75
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 355.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.036
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "549828",
+    "INR46/800"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Tesla"
+  },
+  "schema:model": "INR46800",
+  "schema:name": "tesla-inr46800-2022-549828",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-549828__2022__Capacity__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/tesla/inr46800/2022/550828/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/550828/metadata.jsonld
@@ -1,0 +1,134 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/550828",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide811",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide811"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 22.078,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 82.75,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 355.9,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.036,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR46/800"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 22.078
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 82.75
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 355.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.036
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "550828",
+    "INR46/800"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Tesla"
+  },
+  "schema:model": "INR46800",
+  "schema:name": "tesla-inr46800-2022-550828"
+}

--- a/examples/in/registry/tesla/inr46800/2022/601828/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/601828/metadata.jsonld
@@ -1,0 +1,139 @@
+{
+  "@context": [
+    "https://w3id.org/emmo/domain/battery/context",
+    {
+      "bdf": "https://w3id.org/bdf/",
+      "csvw": "http://www.w3.org/ns/csvw#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "schema": "https://schema.org/"
+    }
+  ],
+  "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/601828",
+  "@type": [
+    "schema:Product",
+    "Battery"
+  ],
+  "hasNegativeElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "Graphite",
+        "rdfs:label": "Graphite"
+      }
+    ],
+    "rdfs:label": "negative electrode"
+  },
+  "hasPositiveElectrode": {
+    "@type": "Electrode",
+    "hasActiveMaterial": [
+      {
+        "@type": "LithiumNickelManganeseCobaltOxide811",
+        "rdfs:label": "LithiumNickelManganeseCobaltOxide811"
+      }
+    ],
+    "rdfs:label": "positive electrode"
+  },
+  "hasProperty": [
+    {
+      "@type": "NominalVoltage",
+      "hasMeasurementUnit": "emmo:Volt",
+      "hasNumberValue": 3.7,
+      "rdfs:label": "nominal voltage"
+    },
+    {
+      "@type": "RatedCapacity",
+      "hasMeasurementUnit": "emmo:AmpereHour",
+      "hasNumberValue": 22.078,
+      "rdfs:label": "rated capacity"
+    },
+    {
+      "@type": "RatedEnergy",
+      "hasMeasurementUnit": "emmo:WattHour",
+      "hasNumberValue": 82.75,
+      "rdfs:label": "rated energy"
+    },
+    {
+      "@type": "Mass",
+      "hasMeasurementUnit": "emmo:Gram",
+      "hasNumberValue": 355.9,
+      "rdfs:label": "mass"
+    },
+    {
+      "@type": "Volume",
+      "hasMeasurementUnit": "emmo:Litre",
+      "hasNumberValue": 0.036,
+      "rdfs:label": "volume"
+    }
+  ],
+  "schema:additionalProperty": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "IEC code",
+      "schema:propertyID": "bdf:iec_code",
+      "schema:value": "INR46/800"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Chemistry",
+      "schema:propertyID": "bdf:chemistry",
+      "schema:value": "li-ion"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Form factor",
+      "schema:propertyID": "bdf:form_factor",
+      "schema:value": "cylindrical"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Nominal voltage",
+      "schema:propertyID": "bdf:nominal_voltage_v",
+      "schema:unitText": "V",
+      "schema:value": 3.7
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated capacity",
+      "schema:propertyID": "bdf:rated_capacity_ah",
+      "schema:unitText": "Ah",
+      "schema:value": 22.078
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Rated energy",
+      "schema:propertyID": "bdf:rated_energy_wh",
+      "schema:unitText": "Wh",
+      "schema:value": 82.75
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Mass",
+      "schema:propertyID": "bdf:mass_g",
+      "schema:unitText": "g",
+      "schema:value": 355.9
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Volume",
+      "schema:propertyID": "bdf:volume_l",
+      "schema:unitText": "L",
+      "schema:value": 0.036
+    }
+  ],
+  "schema:category": "li-ion",
+  "schema:identifier": [
+    "601828",
+    "INR46/800"
+  ],
+  "schema:manufacturer": {
+    "@type": "schema:Organization",
+    "schema:name": "Tesla"
+  },
+  "schema:model": "INR46800",
+  "schema:name": "tesla-inr46800-2022-601828",
+  "schema:subjectOf": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-601828__2022__Capacity__25degC.bdf.parquet#dataset"
+    }
+  ]
+}

--- a/examples/in/registry/tesla/inr46800/2022/metadata.jsonld
+++ b/examples/in/registry/tesla/inr46800/2022/metadata.jsonld
@@ -1,0 +1,2857 @@
+{
+  "@context": [
+    "https://schema.org/",
+    "http://www.w3.org/ns/csvw"
+  ],
+  "@type": "schema:Dataset",
+  "schema:citation": [
+    "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+  ],
+  "schema:creator": [
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "Ank",
+      "schema:givenName": "Manuel",
+      "schema:name": "Manuel Ank",
+      "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+      },
+      "schema:familyName": "Sommer",
+      "schema:givenName": "Alessandro",
+      "schema:name": "Alessandro Sommer",
+      "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "Abo Gamra",
+      "schema:givenName": "Kareem",
+      "schema:name": "Kareem Abo Gamra",
+      "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "Sch\u00f6berl",
+      "schema:givenName": "Jan",
+      "schema:name": "Jan Sch\u00f6berl",
+      "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+      },
+      "schema:familyName": "Leeb",
+      "schema:givenName": "Matthias",
+      "schema:name": "Matthias Leeb",
+      "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+      },
+      "schema:familyName": "Schachtl",
+      "schema:givenName": "Johannes",
+      "schema:name": "Johannes Schachtl",
+      "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+      },
+      "schema:familyName": "Streidel",
+      "schema:givenName": "Noah",
+      "schema:name": "Noah Streidel",
+      "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+      },
+      "schema:familyName": "Stock",
+      "schema:givenName": "Sandro",
+      "schema:name": "Sandro Stock",
+      "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "Schreiber",
+      "schema:givenName": "Markus",
+      "schema:name": "Markus Schreiber",
+      "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "Bilfinger",
+      "schema:givenName": "Philip",
+      "schema:name": "Philip Bilfinger",
+      "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "Allg\u00e4uer",
+      "schema:givenName": "Christian",
+      "schema:name": "Christian Allg\u00e4uer",
+      "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "Rosner",
+      "schema:givenName": "Philipp",
+      "schema:name": "Philipp Rosner",
+      "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+      },
+      "schema:familyName": "Hagemeister",
+      "schema:givenName": "Jan",
+      "schema:name": "Jan Hagemeister",
+      "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "R\u00f6\u00dfle",
+      "schema:givenName": "Matti",
+      "schema:name": "Matti R\u00f6\u00dfle",
+      "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+      },
+      "schema:familyName": "Daub",
+      "schema:givenName": "R\u00fcdiger",
+      "schema:name": "R\u00fcdiger Daub",
+      "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+    },
+    {
+      "@type": "schema:Person",
+      "schema:affiliation": {
+        "@type": "schema:Organization",
+        "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+      },
+      "schema:familyName": "Lienkamp",
+      "schema:givenName": "Markus",
+      "schema:name": "Markus Lienkamp",
+      "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+    }
+  ],
+  "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry.",
+  "schema:hasPart": [
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-186828__2022__HPPC__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: HPPC.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-186828__2022__HPPC__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-186828__2022__HPPC__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-186828__2022__HPPC__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-186828__2022__HPPC__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "HPPC",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - HPPC",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-083828__2022__Capacity_25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-083828__2022__Capacity_25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-083828__2022__Capacity_25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-2022-083828__2022__Capacity_25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-2022-083828__2022__Capacity_25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - TUM__tesla-inr46800-2022-083828__2022__Capacity_25degC.bdf.parquet",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-131828__2022__Capacity__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/131828"
+      },
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: Capacity.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-131828__2022__Capacity__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-131828__2022__Capacity__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-2022-131828__2022__Capacity__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-2022-131828__2022__Capacity__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Capacity",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - Capacity",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-186828__2022__Capacity__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/186828"
+      },
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: Capacity.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-186828__2022__Capacity__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-186828__2022__Capacity__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-2022-186828__2022__Capacity__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-2022-186828__2022__Capacity__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Capacity",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - Capacity",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-444828__2022__Capacity__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/444828"
+      },
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: Capacity.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-444828__2022__Capacity__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-444828__2022__Capacity__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-2022-444828__2022__Capacity__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-2022-444828__2022__Capacity__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Capacity",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - Capacity",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-536828__2022__2C__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/536828"
+      },
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: 2C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-536828__2022__2C__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-536828__2022__2C__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-2022-536828__2022__2C__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-2022-536828__2022__2C__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "2C",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - 2C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-536828__2022__Capacity__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/536828"
+      },
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: Capacity.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-536828__2022__Capacity__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-536828__2022__Capacity__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-2022-536828__2022__Capacity__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-2022-536828__2022__Capacity__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Capacity",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - Capacity",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-549828__2022__Capacity__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/549828"
+      },
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: Capacity.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-549828__2022__Capacity__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-549828__2022__Capacity__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-2022-549828__2022__Capacity__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-2022-549828__2022__Capacity__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Capacity",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - Capacity",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-601828__2022__Capacity__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:about": {
+        "@id": "https://w3id.org/digibatt/battery-data/tesla/inr46800/2022/601828"
+      },
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: Capacity.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-601828__2022__Capacity__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-2022-601828__2022__Capacity__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-2022-601828__2022__Capacity__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-2022-601828__2022__Capacity__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Capacity",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - Capacity",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-536828__2022__1C__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: 1C.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-536828__2022__1C__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__tesla-inr46800-536828__2022__1C__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__tesla-inr46800-536828__2022__1C__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__tesla-inr46800-536828__2022__1C__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "1C",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - 1C",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    },
+    {
+      "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__teslta-inr46800-2022-550828__2022__Capacity__25degC.bdf.parquet#dataset",
+      "@type": "schema:Dataset",
+      "schema:citation": [
+        "Manuel Ank et al 2023 J. Electrochem. Soc. 170 120536"
+      ],
+      "schema:creator": [
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Ank",
+          "schema:givenName": "Manuel",
+          "schema:name": "Manuel Ank",
+          "schema:sameAs": "https://orcid.org/0000-0002-2060-9521"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Sommer",
+          "schema:givenName": "Alessandro",
+          "schema:name": "Alessandro Sommer",
+          "schema:sameAs": "https://orcid.org/0000-0002-2390-1528"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Abo Gamra",
+          "schema:givenName": "Kareem",
+          "schema:name": "Kareem Abo Gamra",
+          "schema:sameAs": "https://orcid.org/0000-0001-9739-8710"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Sch\u00f6berl",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Sch\u00f6berl",
+          "schema:sameAs": "https://orcid.org/0009-0004-7601-0325"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Leeb",
+          "schema:givenName": "Matthias",
+          "schema:name": "Matthias Leeb",
+          "schema:sameAs": "https://orcid.org/0000-0003-1156-9078"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Schachtl",
+          "schema:givenName": "Johannes",
+          "schema:name": "Johannes Schachtl",
+          "schema:sameAs": "https://orcid.org/0009-0007-9108-5327"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Streidel",
+          "schema:givenName": "Noah",
+          "schema:name": "Noah Streidel",
+          "schema:sameAs": "https://orcid.org/0009-0004-2515-2059"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Stock",
+          "schema:givenName": "Sandro",
+          "schema:name": "Sandro Stock",
+          "schema:sameAs": "https://orcid.org/0000-0003-2107-6031"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Schreiber",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Schreiber",
+          "schema:sameAs": "https://orcid.org/0000-0002-6530-0077"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Bilfinger",
+          "schema:givenName": "Philip",
+          "schema:name": "Philip Bilfinger",
+          "schema:sameAs": "https://orcid.org/0000-0002-9100-9689"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Allg\u00e4uer",
+          "schema:givenName": "Christian",
+          "schema:name": "Christian Allg\u00e4uer",
+          "schema:sameAs": "https://orcid.org/0009-0007-8037-895X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Rosner",
+          "schema:givenName": "Philipp",
+          "schema:name": "Philipp Rosner",
+          "schema:sameAs": "https://orcid.org/0000-0001-6481-532X"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Hagemeister",
+          "schema:givenName": "Jan",
+          "schema:name": "Jan Hagemeister",
+          "schema:sameAs": "https://orcid.org/0000-0001-8307-6614"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "R\u00f6\u00dfle",
+          "schema:givenName": "Matti",
+          "schema:name": "Matti R\u00f6\u00dfle",
+          "schema:sameAs": "https://orcid.org/0009-0007-5407-6798"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute for Machine Tools and Industrial Management"
+          },
+          "schema:familyName": "Daub",
+          "schema:givenName": "R\u00fcdiger",
+          "schema:name": "R\u00fcdiger Daub",
+          "schema:sameAs": "https://orcid.org/0000-0002-5120-4228"
+        },
+        {
+          "@type": "schema:Person",
+          "schema:affiliation": {
+            "@type": "schema:Organization",
+            "schema:name": "Technical University of Munich (TUM), Institute of Automotive Technology"
+          },
+          "schema:familyName": "Lienkamp",
+          "schema:givenName": "Markus",
+          "schema:name": "Markus Lienkamp",
+          "schema:sameAs": "https://orcid.org/0000-0002-9263-5323"
+        }
+      ],
+      "schema:description": "A collection of raw data from the publication by Ank et al (doi: 10.1149/1945-7111/ad14d0) curated for integration into the BDF registry. Measurement technique: Capacity.",
+      "schema:distribution": [
+        {
+          "@id": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__teslta-inr46800-2022-550828__2022__Capacity__25degC.bdf.parquet",
+          "@type": "schema:DataDownload",
+          "schema:contentUrl": "https://github.com/digibatt/battery-data/tesla/inr46800/2022/data/TUM__teslta-inr46800-2022-550828__2022__Capacity__25degC.bdf.parquet",
+          "schema:encodingFormat": "application/x-parquet",
+          "schema:name": "TUM__teslta-inr46800-2022-550828__2022__Capacity__25degC.bdf.parquet"
+        }
+      ],
+      "schema:identifier": [
+        "data/TUM__teslta-inr46800-2022-550828__2022__Capacity__25degC.bdf.parquet",
+        "10.1149/1945-7111/ad14d0"
+      ],
+      "schema:inLanguage": "en",
+      "schema:keywords": [
+        "li-ion",
+        "inr46800",
+        "4680",
+        "tesla",
+        "tum",
+        "ank2023",
+        "battery",
+        "INR46/800",
+        "dcir",
+        "rate",
+        "thermal"
+      ],
+      "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+      "schema:measurementTechnique": "Capacity",
+      "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization - Capacity",
+      "schema:variableMeasured": [
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Test Time",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+          "schema:unitText": "s"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Voltage",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+          "schema:unitText": "V"
+        },
+        {
+          "@type": "schema:PropertyValue",
+          "schema:name": "Current",
+          "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+          "schema:unitText": "A"
+        }
+      ],
+      "schema:version": "1.0.0"
+    }
+  ],
+  "schema:identifier": "10.1149/1945-7111/ad14d0",
+  "schema:inLanguage": "en",
+  "schema:keywords": [
+    "li-ion",
+    "inr46800",
+    "4680",
+    "tesla",
+    "tum",
+    "ank2023",
+    "battery",
+    "INR46/800",
+    "dcir",
+    "rate",
+    "thermal"
+  ],
+  "schema:license": "https://spdx.org/licenses/CC-BY-4.0",
+  "schema:name": "Raw Data from Lithium-Ion Cells in Automotive Applications: Tesla 4680 Cylindrical Cell Teardown and Characterization",
+  "schema:url": "https://github.com/digibatt/battery-data/tesla/inr46800/2022",
+  "schema:variableMeasured": [
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Test Time",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#test_time_second",
+      "schema:unitText": "s"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Voltage",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#voltage_volt",
+      "schema:unitText": "V"
+    },
+    {
+      "@type": "schema:PropertyValue",
+      "schema:name": "Current",
+      "schema:propertyID": "https://w3id.org/battery-data-alliance/ontology/battery-data-format#current_ampere",
+      "schema:unitText": "A"
+    }
+  ],
+  "schema:version": "1.0.0"
+}

--- a/examples/registry.ipynb
+++ b/examples/registry.ipynb
@@ -40,7 +40,9 @@
         "## Crawl a trusted source\n",
         "\n",
         "This builds `registry.ttl` and `registry.db` under the default \n",
-        "registry directory (or `BDF_REGISTRY_DIR` if set).\n"
+        "registry directory (or `BDF_REGISTRY_DIR` if set). Here the source is a \n",
+        "small metadata snapshot committed under `examples/in/registry`; swap in the \n",
+        "upstream repo URL (see the commented line) to crawl the full dataset.\n"
       ]
     },
     {
@@ -50,7 +52,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "source = \"https://github.com/DigiBatt/battery-data/tree/main\"\n",
+        "# Build from the metadata snapshot committed under examples/in/registry\n",
+        "# (keeps this notebook offline / CI-friendly).\n",
+        "source = \"in/registry\"\n",
+        "# To crawl the full upstream dataset repo instead, run locally with refresh=True:\n",
+        "# source = \"https://github.com/DigiBatt/battery-data/tree/main\"\n",
         "registry_dir = Path(\"out/registry\")\n",
         "summary = bdf.build_registry(source, registry_dir=registry_dir, refresh=False)\n",
         "summary\n"

--- a/examples/remote_sources.py
+++ b/examples/remote_sources.py
@@ -57,8 +57,6 @@ NON_DATA_URLS: frozenset[str] = frozenset(
         # Metadata example: dataset DOI and landing page (not fetched).
         "https://doi.org/10.5281/zenodo.16994937#digatron-csv-li-ion-hppc",
         "https://zenodo.org/records/17295469",
-        # Registry example: source repository browsed for datasets (not a file read).
-        "https://github.com/DigiBatt/battery-data/tree/main",
         # SPARQL / vocabulary IRIs, not network reads.
         "https://schema.org/Dataset",
         "https://schema.org/name",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ testpaths = ["tests"]
 markers = [
   "slow: may be slow or large I/O",
   "network: requires internet access",
+  "live_network: needs a live socket even with a warm cache",
   "registry: uses remote registry on Zenodo",
   "golden: compares against golden files",
   "perf: performance/smoke thresholds",

--- a/scripts/warm_cache.py
+++ b/scripts/warm_cache.py
@@ -20,6 +20,10 @@ import hashlib
 import sys
 from pathlib import Path
 
+# Fail the warm if the primed cache grows beyond this, to stay clear of
+# GitHub's 10 GB per-repo ``actions/cache`` limit.
+_MAX_CACHE_BYTES = 4 * 1024**3  # 4 GiB
+
 # Make the repo root importable so ``tests.integration`` resolves when this
 # script is run as ``python scripts/warm_cache.py``.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -64,20 +68,31 @@ def emit_key(urls: list[str]) -> str:
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
 
-def warm(urls: list[str]) -> None:
+def warm(urls: list[str], max_bytes: int = _MAX_CACHE_BYTES) -> None:
     """Fetch each URL sequentially into the cache, printing resolved paths.
 
-    Exits non-zero if any fetch raises.
+    Exits non-zero if any fetch raises, or if the cumulative size of the
+    fetched files exceeds ``max_bytes`` — a guard against approaching GitHub's
+    10 GB ``actions/cache`` limit.
 
     Args:
         urls: Sorted list of URL strings to fetch.
+        max_bytes: Cumulative byte ceiling for the warmed cache.
     """
+    total = 0
     for url in urls:
         try:
             path = fetch.fetch_url(url)
         except Exception as e:  # noqa: BLE001
             sys.exit(f"ERROR: fetch failed for {url}: {e}")
+        total += Path(path).stat().st_size
         print(f"  cached: {url} -> {path}")
+        if total > max_bytes:
+            sys.exit(
+                f"ERROR: warmed cache reached {total / 1024**3:.2f} GiB, "
+                f"exceeding the {max_bytes / 1024**3:.2f} GiB limit "
+                f"(after fetching {url})."
+            )
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/bdf/fetch.py
+++ b/src/bdf/fetch.py
@@ -130,6 +130,11 @@ def fetch_url(
                 return dest
             except Exception as e:
                 last_err = e
+                # A blocked socket (CI with --block-cached-sockets on a cache
+                # miss) is not transient: fail fast instead of burning the
+                # retry backoff. Match by name to avoid a pytest_socket import.
+                if type(e).__name__ == "SocketBlockedError":
+                    raise
                 # small backoff on transient failures
                 time.sleep(0.8 * (attempt + 1))
         # try next alt URL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,20 +10,55 @@ HERE = Path(__file__).parent
 DATA = HERE / "data"
 
 
+def pytest_addoption(parser):
+    """Register the ``--block-cached-sockets`` flag.
+
+    Args:
+        parser: The pytest argument parser.
+    """
+    parser.addoption(
+        "--block-cached-sockets",
+        action="store_true",
+        default=False,
+        help=(
+            "Keep sockets blocked for cache-backed ``network`` tests. Used on CI "
+            "after the warm cache restores: a cache miss then fails loudly with a "
+            "SocketBlockedError instead of silently re-downloading. Tests marked "
+            "``live_network`` still get a socket."
+        ),
+    )
+
+
 def pytest_collection_modifyitems(config, items):
-    """Re-enable sockets for ``network``-marked items.
+    """Re-enable sockets for network-marked items.
 
     ``--disable-socket`` (set in ``addopts``) blocks all socket access by
-    default; ``network`` tests legitimately need the network, so grant them an
-    ``enable_socket`` marker.
+    default. ``network`` tests legitimately touch the network, so they normally
+    get an ``enable_socket`` marker. With ``--block-cached-sockets`` (CI, post
+    warm-cache):
+
+    * ``live_network`` tests always get a real socket.
+    * ``notebooks`` tests get ``allow_hosts`` limited to localhost so the
+      Jupyter kernel's socket pair / ZMQ channels work, while a remote (cache
+      miss) fetch is still blocked and fails loudly.
+    * other cache-backed ``network`` tests stay fully blocked, so a cache miss
+      raises ``SocketBlockedError`` instead of silently re-downloading.
 
     Args:
         config: The pytest config object.
         items: The collected test items, mutated in place.
     """
+    block_cached = config.getoption("--block-cached-sockets")
     for item in items:
-        if item.get_closest_marker("network"):
+        if item.get_closest_marker("live_network"):
             item.add_marker(pytest.mark.enable_socket)
+            continue
+        if not item.get_closest_marker("network"):
+            continue
+        if not block_cached:
+            item.add_marker(pytest.mark.enable_socket)
+        elif item.get_closest_marker("notebooks"):
+            item.add_marker(pytest.mark.allow_hosts(["127.0.0.1", "::1"]))
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -20,10 +20,35 @@ KERNEL_NAME = os.getenv("BDF_NOTEBOOK_KERNEL", "python3")
 TIMEOUT = int(os.getenv("BDF_NOTEBOOK_TIMEOUT", "600"))
 
 
+@pytest.fixture
+def _block_kernel_network(request, monkeypatch):
+    """Route the notebook kernel's outbound HTTP(S) to a dead proxy under ``--block-cached-sockets``.
+
+    ``pytest-socket`` only patches sockets in the pytest process; the Jupyter
+    kernel runs in a separate subprocess and would otherwise re-download on a
+    cache miss, silently defeating the guard. The kernel inherits ``os.environ``,
+    so pointing ``HTTP(S)_PROXY`` at a dead port makes any cache-miss fetch fail
+    loudly while a cache hit (no network) still passes. ``requests``/urllib
+    honour these; ZMQ kernel<->client traffic is raw-socket and proxy-agnostic,
+    and ``NO_PROXY`` exempts localhost for good measure.
+
+    Args:
+        request: The pytest request, used to read ``--block-cached-sockets``.
+        monkeypatch: Fixture used to set and auto-restore the proxy env vars.
+    """
+    if not request.config.getoption("--block-cached-sockets"):
+        return
+    dead = "http://127.0.0.1:9"
+    monkeypatch.setenv("HTTP_PROXY", dead)
+    monkeypatch.setenv("HTTPS_PROXY", dead)
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1,::1,localhost")
+
+
 @pytest.mark.notebooks
 @pytest.mark.slow
 @pytest.mark.network
 @pytest.mark.parametrize("notebook_path", NOTEBOOKS, ids=lambda p: p.name)
+@pytest.mark.usefixtures("_block_kernel_network")
 def test_example_notebooks_execute(notebook_path: Path):
     if not NOTEBOOKS:
         pytest.skip("No notebooks found under examples/")

--- a/tests/unit/test_notebook_remote_sources.py
+++ b/tests/unit/test_notebook_remote_sources.py
@@ -98,13 +98,13 @@ def _notebook_urls() -> set[str]:
 def test_notebook_url_extraction_count() -> None:
     """Canary on the extractor: the notebooks reference a known number of URLs.
 
-    Currently 11: 5 fetched data files (all in ``REMOTE_DATA_SOURCES``, 2 of which
-    also appear in ``ALL_CASES``) plus 6 non-data references (``NON_DATA_URLS``).
+    Currently 10: 5 fetched data files (all in ``REMOTE_DATA_SOURCES``, 2 of which
+    also appear in ``ALL_CASES``) plus 5 non-data references (``NON_DATA_URLS``).
     Bump this when a notebook adds or removes a URL — a silent drop means the
     nbformat/IPython-transformer/AST extraction has regressed.
     """
     urls = _notebook_urls()
-    assert len(urls) == 11, f"expected 11 notebook URLs, extracted {len(urls)}:\n" + "\n".join(
+    assert len(urls) == 10, f"expected 10 notebook URLs, extracted {len(urls)}:\n" + "\n".join(
         f"  - {u}" for u in sorted(urls)
     )
 

--- a/tests/unit/test_spec_ontology.py
+++ b/tests/unit/test_spec_ontology.py
@@ -724,6 +724,7 @@ def test_get_snapshot_writes_to_dest(tmp_path: Path) -> None:
 
 
 @pytest.mark.network
+@pytest.mark.live_network
 def test_bundled_snapshot_is_up_to_date(tmp_path: Path) -> None:
     """Bundled snapshot matches live ontology. Run `bdf-update-snapshot` if this fails."""
     fresh_path = ColumnOntology.get_snapshot(dest=tmp_path / "fresh.ttl")

--- a/tests/unit/test_warm_cache.py
+++ b/tests/unit/test_warm_cache.py
@@ -20,12 +20,15 @@ import hashlib
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from examples.remote_sources import REMOTE_DATA_SOURCES  # noqa: E402
-from scripts.warm_cache import emit_key, url_sources  # noqa: E402
+from scripts import warm_cache  # noqa: E402
+from scripts.warm_cache import emit_key, url_sources, warm  # noqa: E402
 from tests.integration.test_cases import ALL_CASES  # noqa: E402
 
 # A couple of known files in the Zenodo reference record (18986774). Pinned here
@@ -89,3 +92,48 @@ class TestEmitKey:
         urls = url_sources()
         changed = sorted([*urls, "https://example.com/new-file.csv"])
         assert emit_key(changed) != emit_key(urls)
+
+
+class TestWarmSizeGuard:
+    """Tests for the cumulative cache-size ceiling enforced by ``warm``.
+
+    ``warm`` must abort (non-zero exit) once the total bytes of the fetched
+    files exceed its ``max_bytes`` ceiling, so a runaway data set fails the CI
+    warm step before the oversized cache is ever saved to ``actions/cache``.
+    """
+
+    @staticmethod
+    def _fake_fetch(monkeypatch, tmp_path: Path, size_per_file: int):
+        """Patch ``fetch.fetch_url`` to write a file of ``size_per_file`` bytes.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+            tmp_path: Directory to write the fake cached files into.
+            size_per_file: Byte length of each written file.
+        """
+
+        def _fetch(url: str, *args, **kwargs) -> Path:
+            dest = tmp_path / warm_cache.fetch._safe_cache_name(url, None)
+            dest.write_bytes(b"\0" * size_per_file)
+            return dest
+
+        monkeypatch.setattr(warm_cache.fetch, "fetch_url", _fetch)
+
+    def test_passes_when_total_under_limit(self, monkeypatch, tmp_path) -> None:
+        self._fake_fetch(monkeypatch, tmp_path, size_per_file=10)
+        urls = ["https://example.com/a.csv", "https://example.com/b.csv"]
+        # 20 bytes total, limit 100 -> no exit.
+        warm(urls, max_bytes=100)
+
+    def test_exits_when_total_exceeds_limit(self, monkeypatch, tmp_path) -> None:
+        self._fake_fetch(monkeypatch, tmp_path, size_per_file=60)
+        urls = ["https://example.com/a.csv", "https://example.com/b.csv"]
+        # First file 60 <= 100, second pushes total to 120 > 100 -> exit.
+        with pytest.raises(SystemExit) as exc:
+            warm(urls, max_bytes=100)
+        assert "exceeding" in str(exc.value)
+
+    def test_exits_on_first_oversized_file(self, monkeypatch, tmp_path) -> None:
+        self._fake_fetch(monkeypatch, tmp_path, size_per_file=200)
+        with pytest.raises(SystemExit):
+            warm(["https://example.com/big.csv"], max_bytes=100)


### PR DESCRIPTION
## Summary
Makes the CI network test suite deterministic against the warm cache. After the cache is restored, sockets stay blocked so a cache miss fails loudly with a `SocketBlockedError` instead of silently re-downloading and masking a stale or incomplete cache. Adds a cache-size guard, closes the subprocess (notebook kernel) network gap, and converts the registry example to run fully offline.

## Features
- `--block-cached-sockets` pytest flag and `live_network` marker: after the warm cache restores, cache-backed `network` tests stay socket-blocked, while `live_network` tests always get a real socket and `notebooks` tests are limited to localhost for the Jupyter kernel ([282deca](https://github.com/tomjholland/battery-data-format/commit/282deca))
- Warm-cache size ceiling: `warm()` tracks cumulative fetched bytes and aborts non-zero past a 4 GiB limit, keeping the primed cache clear of GitHub's 10 GB `actions/cache` cap before an oversized cache is ever saved ([e0eac08](https://github.com/tomjholland/battery-data-format/commit/e0eac08))
- Registry example runs offline from a committed metadata snapshot under `examples/in/registry` instead of browsing the remote DigiBatt repository, so the notebook needs no network under a warm cache with blocked sockets ([ee4c1c1](https://github.com/tomjholland/battery-data-format/commit/ee4c1c1))

## Fixes
- `fetch_url` re-raises a `SocketBlockedError` immediately instead of burning the retry backoff — a blocked socket on a cache miss is not transient, so failing fast surfaces it without delay (matched by class name to avoid importing `pytest_socket` into the package) ([496639d](https://github.com/tomjholland/battery-data-format/commit/496639d))

## Tests
- Block the Jupyter kernel subprocess's network on a cache miss: `pytest-socket` only patches the pytest process, so the `_block_kernel_network` fixture points the kernel's `HTTP(S)_PROXY` at a dead port under `--block-cached-sockets` (with `NO_PROXY` exempting localhost so ZMQ kernel traffic is unaffected) ([775df15](https://github.com/tomjholland/battery-data-format/commit/775df15))
- `TestWarmSizeGuard` covers the size ceiling: total under limit passes, cumulative overflow exits, and a single oversized file exits ([e0eac08](https://github.com/tomjholland/battery-data-format/commit/e0eac08))

## CI
- Split the warm cache into separate `actions/cache/restore` and `actions/cache/save` steps, saving only on a miss after a successful warm to avoid redundant re-uploads on every hit ([9e8918d](https://github.com/tomjholland/battery-data-format/commit/9e8918d))


🤖 Generated with [Claude Code](https://claude.com/claude-code)
