### PR TITLE
fix(units): don't read a quantity name as a unit in header parsing

### DIFF
--- a/src/bdf/units/core.py
+++ b/src/bdf/units/core.py
@@ -49,6 +49,14 @@ _UNIT_ALIAS = {
     "per": "/",
 }
 
+# Tokens Pint recognises as angular units (1 cycle = 1 turn = 1 revolution = 2*pi
+# rad) but which, in a cycler column header, always denote a dimensionless count --
+# never an angle. Never accept them as a unit, or a cycle/turn count would be
+# silently scaled by 2*pi.
+_ANGULAR_UNIT_TOKENS = frozenset(
+    {"cycle", "cycles", "turn", "turns", "revolution", "revolutions"}
+)
+
 
 _SPLIT = re.compile(r"[ _\-]+")
 _HASH  = re.compile(r"^(?P<name>.+?)#(?P<unit>.+)$")
@@ -96,16 +104,25 @@ def parse_from_header(header: str) -> Tuple[str, Optional[str], str]:
         return base, unit, "paren"
 
     tokens = [t for t in _SPLIT.split(h.lower()) if t]
-    # try longest -> shortest suffix; accept only if Pint can parse the unit
+    # Try longest -> shortest suffix; accept only if Pint can parse the unit. Two
+    # guards stop a quantity *name* from being misread as a unit:
+    #   1. require a non-empty base remainder, so a suffix never consumes the whole
+    #      header (a bare "Cycle"/"Bar"/"V" column is a name, not a unit); and
+    #   2. reject angular tokens (cycle/turn/revolution), which Pint scales by 2*pi
+    #      but which always mean a dimensionless count here (e.g. a "z cycle" count).
+    # See test_parse_from_header.
     for i in range(min(6, len(tokens)), 0, -1):
-        unit = _norm_tokens(tokens[-i:])
+        base_tokens = tokens[:-i]
+        unit_tokens = tokens[-i:]
+        if not base_tokens or any(t in _ANGULAR_UNIT_TOKENS for t in unit_tokens):
+            continue
+        unit = _norm_tokens(unit_tokens)
         if not unit:
             continue
         try:
             if has_pint:
                 ureg.Unit(unit)  # validate with Pint
-            base = " ".join(tokens[:-i]) or h
-            return base, unit, "snake"
+            return " ".join(base_tokens), unit, "snake"
         except Exception:
             continue
 

--- a/src/bdf/units/core.py
+++ b/src/bdf/units/core.py
@@ -53,9 +53,7 @@ _UNIT_ALIAS = {
 # rad) but which, in a cycler column header, always denote a dimensionless count --
 # never an angle. Never accept them as a unit, or a cycle/turn count would be
 # silently scaled by 2*pi.
-_ANGULAR_UNIT_TOKENS = frozenset(
-    {"cycle", "cycles", "turn", "turns", "revolution", "revolutions"}
-)
+_ANGULAR_UNIT_TOKENS = frozenset({"cycle", "cycles", "turn", "turns", "revolution", "revolutions"})
 
 
 _SPLIT = re.compile(r"[ _\-]+")

--- a/tests/unit/test_parse_from_header.py
+++ b/tests/unit/test_parse_from_header.py
@@ -28,7 +28,7 @@ def test_bare_quantity_name_is_not_parsed_as_a_unit(header: str) -> None:
         "Cycle Count / 1",
         "Step Count",
         "Step Index / 1",
-        "z cycle",          # Biologic cycle-count synonym: unit word follows a prefix
+        "z cycle",  # Biologic cycle-count synonym: unit word follows a prefix
         "cell turn",
         "3 revolutions",
     ],
@@ -39,9 +39,9 @@ def test_count_headers_never_acquire_an_angular_unit(header: str) -> None:
     # count would be scaled by 2*pi during conversion.
     _base, unit, _source = parse_from_header(header)
     if unit is not None:
-        assert not any(
-            tok in unit.lower() for tok in ("cycle", "turn", "revolution", "rad")
-        ), f"{header!r} acquired an angular unit {unit!r}"
+        assert not any(tok in unit.lower() for tok in ("cycle", "turn", "revolution", "rad")), (
+            f"{header!r} acquired an angular unit {unit!r}"
+        )
 
 
 def test_explicit_units_still_parse() -> None:

--- a/tests/unit/test_parse_from_header.py
+++ b/tests/unit/test_parse_from_header.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from bdf.units.core import has_pint, parse_from_header
+
+
+# Quantity names that happen to collide with real Pint units. A bare column header
+# is a quantity *name*, not a unit, so these must NOT be parsed as carrying a unit.
+# "cycle" is the dangerous one: Pint defines it as the angular unit (1 cycle = 2*pi
+# rad), so reading "Cycle" as a unit silently scaled dimensionless cycle counts by
+# 2*pi during conversion. See the header parser in bdf/units/core.py.
+@pytest.mark.parametrize(
+    "header",
+    ["Cycle", "cycle", "Turn", "Revolution", "Step", "Index"],
+)
+def test_bare_quantity_name_is_not_parsed_as_a_unit(header: str) -> None:
+    base, unit, source = parse_from_header(header)
+    assert unit is None, f"{header!r} should have no unit, got {unit!r}"
+    assert source == "none"
+    assert base == header
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Cycle Count",
+        "Cycle Count / 1",
+        "Step Count",
+        "Step Index / 1",
+        "z cycle",          # Biologic cycle-count synonym: unit word follows a prefix
+        "cell turn",
+        "3 revolutions",
+    ],
+)
+def test_count_headers_never_acquire_an_angular_unit(header: str) -> None:
+    # Whatever the parser does with the base/unit split, it must never claim an
+    # angular unit (cycle/turn/revolution/radian) for a count column -- otherwise the
+    # count would be scaled by 2*pi during conversion.
+    _base, unit, _source = parse_from_header(header)
+    if unit is not None:
+        assert not any(
+            tok in unit.lower() for tok in ("cycle", "turn", "revolution", "rad")
+        ), f"{header!r} acquired an angular unit {unit!r}"
+
+
+def test_explicit_units_still_parse() -> None:
+    assert parse_from_header("Voltage#V") == ("Voltage", "V", "hash")
+    assert parse_from_header("Current (A)") == ("Current", "A", "paren")
+
+
+@pytest.mark.skipif(not has_pint, reason="snake-suffix unit inference requires Pint")
+def test_snake_suffix_unit_still_parses_with_a_real_base() -> None:
+    # A genuine "name + trailing unit" snake header must still resolve, and must keep
+    # a non-empty base (the guard only rejects whole-header-as-unit matches).
+    base, unit, source = parse_from_header("voltage_V")
+    assert base == "voltage"
+    assert unit == "V"
+    assert source == "snake"
+
+    base, unit, source = parse_from_header("specific_energy_watt_hour_per_kilogram")
+    assert base, "base must not be empty"
+    assert unit is not None and "h" in unit.lower()
+    assert source == "snake"


### PR DESCRIPTION
`parse_from_header()` could misread a column **name** as a **unit**, silently corrupting cycle-count data. Pint defines `cycle = turn = revolution = 2π rad`, so a column named `Cycle` (Neware) or `z cycle` (Biologic) parsed as an angle, and normalization then scaled the dimensionless cycle count by 2*pi, every `cycle_count` value became `6.283185…`. `Step`/`Index` counts were spared only because Pint has no `step` unit.

## Root cause

In the snake-suffix branch, a token suffix was accepted as the unit even when it consumed the **entire** header (`base = " ".join(tokens[:-i]) or h` fell back to the full header as base but still returned the bogus unit), and angular unit-words were treated like any other unit.

```text
parse_from_header("Cycle")    -> ("Cycle", "cycle", "snake")   # before
parse_from_header("z cycle")  -> ("z",     "cycle", "snake")   # before
# normalize: convert_series(series, "cycle", "1")  ->  x 2π
```

## Fix

A cycler column header is a quantity name with an optional trailing unit, never a bare or angular unit. Two small, complementary guards in `parse_from_header`:

1. **require a non-empty base remainder** → a suffix can't consume the whole header (`Cycle`, `Bar`, `V`, `Ah`);
2. **reject angular unit tokens** (`cycle`/`turn`/`revolution`) → always a dimensionless count in this domain (covers `z cycle`, where the unit-word trails a prefix).

```text
parse_from_header("Cycle")    -> ("Cycle",   None, "none")  # after
parse_from_header("z cycle")  -> ("z cycle", None, "none")  # after
```

Counts now pass through unscaled. Explicit (`Voltage#V`, `Current (A)`) and genuine snake `name + unit` (`voltage_V`, `Power / W`) headers are unaffected.

## Testing

- New `tests/unit/test_parse_from_header.py` covers both collision shapes (whole-header and prefixed-angular) and confirms real units still parse.
- End-to-end: re-converting a Neware `.ndax` now yields `cycle_count = 1` (was `6.283185…`); voltage/current/capacity/step columns unchanged.
- Full unit suite + integration suite (real Neware/Biologic/Digatron fixtures) pass. *(The pre-existing `test_bundled_snapshot_is_up_to_date` failure on `main` is an unrelated stale bundled snapshot.)*