### PR TITLE
feat(plugins): arbin_xlsx importer for Arbin MITS Excel exports

### DIFF
--- a/src/bdf/plugins.py
+++ b/src/bdf/plugins.py
@@ -190,6 +190,13 @@ NEWARE_XLSX = Plugin(
     table_parser=ExcelParser(normalizer=NORMALIZERS["neware"], sheet_name="record"),
 )
 
+# Arbin MITS Excel exports: data lives in a per-channel sheet whose name varies by
+# MITS version (Channel_1-002, Channel-6_1, Channel_6_1, ...); Global_Info carries
+# test metadata and ACIM_chan_*/Statistics* sheets (EIS, summaries) are not read.
+ARBIN_XLSX = Plugin(
+    table_parser=ExcelParser(normalizer=NORMALIZERS["arbin"], sheet_pattern=r"^Channel[_-]"),
+)
+
 NOVONIX_CSV = Plugin(
     table_parser=DelimTxtParser(normalizer=NORMALIZERS["novonix"]),
     metadata_parser=TxtPreambleParser(magic=("[summary]", "[data]", "novonix uhpc data file", "novonix")),
@@ -218,6 +225,7 @@ PLUGINS: dict[str, Plugin] = PluginDict(
         "maccor_csv": MACCOR_CSV,
         "neware_csv": NEWARE_CSV,
         "neware_xlsx": NEWARE_XLSX,
+        "arbin_xlsx": ARBIN_XLSX,
         "novonix_csv": NOVONIX_CSV,
         "neware_nda": NEWARE_NDA,
         "bdf_csv": BDF_CSV,

--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -633,7 +633,13 @@ class TableNormalizer(BaseModel):
 # several file formats (e.g. ``"neware"`` backs both the CSV and XLSX sources).
 # ---------------------------------------------------------------------------
 
-_ARBIN_DT_FMTS = ("%m/%d/%Y %H:%M:%S%.f", "%m/%d/%Y %H:%M:%S", "%Y-%m-%d %H:%M:%S")
+_ARBIN_DT_FMTS = (
+    "%m/%d/%Y %H:%M:%S%.f",
+    "%m/%d/%Y %H:%M:%S",
+    "%Y-%m-%d %H:%M:%S%.f",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y/%m/%d %H:%M:%S",
+)
 _DIGATRON_DT_FMTS = (
     "%Y-%m-%d %H:%M:%S%.f%:z",
     "%Y-%m-%d %H:%M:%S%:z",
@@ -644,15 +650,43 @@ _LANDT_DT_FMTS = ("%Y-%m-%d %H:%M:%S",)
 _MACCOR_DT_FMTS = ("%d-%b-%y %I:%M:%S %p", "%d-%b-%y %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%m/%d/%Y %H:%M")
 _NEWARE_DT_FMTS = ("%Y-%m-%d %H:%M:%S%.f", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S")
 
+# Arbin exports use two header dialects: MITS CSV/newer Excel use spaces before the
+# parenthesised unit ("Test Time (s)"); older MITS Excel uses underscores and no space
+# ("Test_Time(s)"). Both are covered below and share this one normalizer across the
+# arbin_csv and arbin_xlsx plugins.
 ARBIN = TableNormalizer(
-    test_time_second=(Syn(hdr="Test Time ({unit})"),),
-    voltage_volt=(Syn(hdr="Voltage ({unit})"),),
-    current_ampere=(Syn(hdr="Current ({unit})"),),
-    unix_time_second=(DateTimeSyn(syn=Syn(hdr="Date Time"), fmts=_ARBIN_DT_FMTS),),
-    cycle_count=(Syn(hdr="Cycle Index"),),
-    step_id=(Syn(hdr="Step Index"),),
-    record_index=(Syn(hdr="Data Point"),),
-    step_time_second=(Syn(hdr="Step Time ({unit})"),),
+    test_time_second=(
+        Syn(hdr="Test Time ({unit})"),
+        Syn(hdr="Test_Time({unit})"),
+    ),
+    voltage_volt=(
+        Syn(hdr="Voltage ({unit})"),
+        Syn(hdr="Voltage({unit})"),
+    ),
+    current_ampere=(
+        Syn(hdr="Current ({unit})"),
+        Syn(hdr="Current({unit})"),
+    ),
+    unix_time_second=(
+        DateTimeSyn(syn=Syn(hdr="Date Time"), fmts=_ARBIN_DT_FMTS),
+        DateTimeSyn(syn=Syn(hdr="Date_Time"), fmts=_ARBIN_DT_FMTS),
+    ),
+    cycle_count=(
+        Syn(hdr="Cycle Index"),
+        Syn(hdr="Cycle_Index"),
+    ),
+    step_id=(
+        Syn(hdr="Step Index"),
+        Syn(hdr="Step_Index"),
+    ),
+    record_index=(
+        Syn(hdr="Data Point"),
+        Syn(hdr="Data_Point"),
+    ),
+    step_time_second=(
+        Syn(hdr="Step Time ({unit})"),
+        Syn(hdr="Step_Time({unit})"),
+    ),
     temperature_t1_celsius=(
         Syn(hdr="Aux_Temperature_1 (C)"),
         Syn(hdr="Aux_Temperature_1 ({unit})"),

--- a/src/bdf/table_parsers.py
+++ b/src/bdf/table_parsers.py
@@ -604,12 +604,21 @@ class ExcelParser(TableParser):
         """
         import fastexcel
 
+        assert self.sheet_pattern is not None  # guarded by the single caller
         sheets = fastexcel.read_excel(path).sheet_names
-        pattern = re.compile(self.sheet_pattern or "", re.IGNORECASE)
-        for name in sheets:
-            if pattern.search(name):
-                return name
-        raise ValueError(f"no sheet matching {self.sheet_pattern!r} in {path.name!r}; sheets: {sheets}")
+        pattern = re.compile(self.sheet_pattern, re.IGNORECASE)
+        matches = [name for name in sheets if pattern.search(name)]
+        if not matches:
+            raise ValueError(f"no sheet matching {self.sheet_pattern!r} in {path.name!r}; sheets: {sheets}")
+        if len(matches) > 1:
+            # e.g. a multi-channel Arbin export in one workbook: silently reading the
+            # first channel would drop the others' data. Mirror the multi-sheet error
+            # in _read_sheet and make the caller choose.
+            raise ValueError(
+                f"multiple sheets match {self.sheet_pattern!r} in {path.name!r}: {matches}; "
+                "specify `sheet_name` or `sheet_id` to disambiguate."
+            )
+        return matches[0]
 
     def _read_sheet(self, path: str | Path, *, read_options: dict[str, Any], **extra: Any) -> pl.DataFrame:
         """Run ``pl.read_excel`` with the reader's sheet/column config and assert a single sheet.

--- a/src/bdf/table_parsers.py
+++ b/src/bdf/table_parsers.py
@@ -13,6 +13,7 @@ Polars is licensed under MIT: https://github.com/pola-rs/polars/blob/main/LICENS
 from __future__ import annotations
 
 import inspect
+import re
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
@@ -539,6 +540,15 @@ class ExcelParser(TableParser):
         default=None,
         description=_polars_param_desc(pl.read_excel, "sheet_name"),
     )
+    sheet_pattern: str | None = Field(
+        default=None,
+        description=(
+            "Case-insensitive regex matched against the workbook's sheet names; the first "
+            "matching sheet is read. For vendors whose data-sheet name varies per export "
+            "(e.g. Arbin's Channel_1-002 / Channel-6_1 / Channel_6_1). Mutually exclusive "
+            "with sheet_id/sheet_name."
+        ),
+    )
     has_header: bool = Field(
         default=True,
         description=_polars_param_desc(pl.read_excel, "has_header"),
@@ -576,7 +586,30 @@ class ExcelParser(TableParser):
                 "If your data has no headers, read directly with polars.read_excel(..., has_header=False) "
                 "then normalize with the TableNormalizer.normalize() method."
             )
+        if self.sheet_pattern is not None and (self.sheet_id is not None or self.sheet_name is not None):
+            raise ValueError("sheet_pattern is mutually exclusive with sheet_id/sheet_name")
         return self
+
+    def _resolve_sheet_name(self, path: Path) -> str:
+        """Resolve ``sheet_pattern`` to a concrete sheet name for ``path``.
+
+        Args:
+            path: Local file path whose sheet names are enumerated.
+
+        Returns:
+            The first sheet name matching ``sheet_pattern`` (case-insensitive).
+
+        Raises:
+            ValueError: If no sheet matches the pattern.
+        """
+        import fastexcel
+
+        sheets = fastexcel.read_excel(path).sheet_names
+        pattern = re.compile(self.sheet_pattern or "", re.IGNORECASE)
+        for name in sheets:
+            if pattern.search(name):
+                return name
+        raise ValueError(f"no sheet matching {self.sheet_pattern!r} in {path.name!r}; sheets: {sheets}")
 
     def _read_sheet(self, path: str | Path, *, read_options: dict[str, Any], **extra: Any) -> pl.DataFrame:
         """Run ``pl.read_excel`` with the reader's sheet/column config and assert a single sheet.
@@ -597,6 +630,8 @@ class ExcelParser(TableParser):
             kwargs["sheet_id"] = self.sheet_id
         if self.sheet_name is not None:
             kwargs["sheet_name"] = self.sheet_name
+        if self.sheet_pattern is not None:
+            kwargs["sheet_name"] = self._resolve_sheet_name(Path(path))
         if self.columns is not None:
             kwargs["columns"] = self.columns
         if read_options:
@@ -631,7 +666,7 @@ class ExcelParser(TableParser):
         Returns:
             List of column header names from the specified sheet.
         """
-        return self._read_sheet(Path(path), read_options={**(self.read_options or {}), "n_rows": 0}).columns
+        return self._read_sheet(resolve_source(path), read_options={**(self.read_options or {}), "n_rows": 0}).columns
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -36,6 +36,14 @@ _ZENODO_NEWARE_TIME_BUG_URL = (
 )
 _ZENODO_MACCOR_URL = f"{_ZENODO_BASE}/faraday__lg-INR21700M50-2019-002__2019-06-02__rate__25degC__maccor.csv/content"
 _ZENODO_ARBIN_URL = f"{_ZENODO_BASE}/shandong__nacr32140-mp10__2023-10-10__pulse__25degC__arbin.CSV/content"
+_ZENODO_XLSX_BASE = "https://zenodo.org/api/records/21337233/files"
+_ZENODO_ARBIN_XLSX_OCV_URL = f"{_ZENODO_XLSX_BASE}/UCCS__ANR26650M1B-A002__2021__OCV-S4__-25degC__Arbin.xlsx/content"
+_ZENODO_ARBIN_XLSX_CAP_URL = (
+    f"{_ZENODO_XLSX_BASE}/Stanford__IFPR26650-YX05__20231012__Capacity__25degC__Arbin.xlsx/content"
+)
+_ZENODO_ARBIN_XLSX_EIS_URL = (
+    f"{_ZENODO_XLSX_BASE}/Oxford__SLPBB142124-01__20240812__DynamicMBTF__25degC__Arbin__Wb1.xlsx/content"
+)
 
 
 class ColExpect(NamedTuple):
@@ -481,6 +489,120 @@ ALL_CASES: list[tuple[str, SampleCase]] = [
                 ),
             },
             marks=(pytest.mark.network,),
+        ),
+    ),
+    (
+        "arbin_xlsx/zenodo_21337233_ocv_micro",
+        SampleCase(
+            source=_ZENODO_ARBIN_XLSX_OCV_URL,
+            is_url=True,
+            plugin_id="arbin_xlsx",
+            ext_ids=frozenset({"neware_xlsx", "arbin_xlsx"}),
+            meta_ids=frozenset(PLUGINS),
+            cols_id="arbin_xlsx",
+            detect_id="arbin_xlsx",
+            deciding_stage="columns",
+            expected_columns={
+                # underscore header dialect (older MITS Excel); 39-row micro-fixture
+                "test_time_second": ColExpect("Test_Time(s)", 1.0),
+                "voltage_volt": ColExpect("Voltage(V)", 1.0),
+                "current_ampere": ColExpect("Current(A)", 1.0),
+                "unix_time_second": ColExpect("Date_Time", 1.0, is_datetime=True),
+                "cycle_count": ColExpect("Cycle_Index", 1.0),
+                "step_id": ColExpect("Step_Index", 1.0),
+                "record_index": ColExpect("Data_Point", 1.0),
+                "step_time_second": ColExpect("Step_Time(s)", 1.0),
+            },
+            marks=(
+                pytest.mark.network,
+                pytest.mark.skipif(
+                    pytest.importorskip("fastexcel", reason="fastexcel not installed") is None,
+                    reason="fastexcel not installed",
+                ),
+            ),
+        ),
+    ),
+    (
+        "arbin_xlsx/zenodo_21337233_capacity",
+        SampleCase(
+            source=_ZENODO_ARBIN_XLSX_CAP_URL,
+            is_url=True,
+            plugin_id="arbin_xlsx",
+            ext_ids=frozenset({"neware_xlsx", "arbin_xlsx"}),
+            meta_ids=frozenset(PLUGINS),
+            cols_id="arbin_xlsx",
+            detect_id="arbin_xlsx",
+            deciding_stage="columns",
+            expected_columns={
+                # underscore dialect without Data_Point (lithiumwerks-style export)
+                "test_time_second": ColExpect("Test_Time(s)", 1.0),
+                "voltage_volt": ColExpect("Voltage(V)", 1.0),
+                "current_ampere": ColExpect("Current(A)", 1.0),
+                "unix_time_second": ColExpect("Date_Time", 1.0, is_datetime=True),
+                "cycle_count": ColExpect("Cycle_Index", 1.0),
+                "step_id": ColExpect("Step_Index", 1.0),
+                "step_time_second": ColExpect("Step_Time(s)", 1.0),
+            },
+            marks=(
+                pytest.mark.network,
+                pytest.mark.skipif(
+                    pytest.importorskip("fastexcel", reason="fastexcel not installed") is None,
+                    reason="fastexcel not installed",
+                ),
+            ),
+        ),
+    ),
+    (
+        "arbin_xlsx/zenodo_21337233_dynamic_eis",
+        SampleCase(
+            source=_ZENODO_ARBIN_XLSX_EIS_URL,
+            is_url=True,
+            plugin_id="arbin_xlsx",
+            ext_ids=frozenset({"neware_xlsx", "arbin_xlsx"}),
+            meta_ids=frozenset(PLUGINS),
+            cols_id="arbin_xlsx",
+            detect_id="arbin_xlsx",
+            deciding_stage="columns",
+            expected_columns={
+                # space header dialect (newer MITS Excel); multi-sheet workbook whose
+                # ACIM_chan (EIS) and Statistics sheets must be ignored by the parser
+                "test_time_second": ColExpect("Test Time (s)", 1.0),
+                "voltage_volt": ColExpect("Voltage (V)", 1.0),
+                "current_ampere": ColExpect("Current (A)", 1.0),
+                "unix_time_second": ColExpect("Date Time", 1.0, is_datetime=True),
+                "cycle_count": ColExpect("Cycle Index", 1.0),
+                "step_id": ColExpect("Step Index", 1.0),
+                "record_index": ColExpect("Data Point", 1.0),
+                "step_time_second": ColExpect("Step Time (s)", 1.0),
+                "power_watt": ColExpect("Power (W)", 1.0),
+                "temperature_t1_celsius": ColExpect("Aux_Temperature_1 (C)", 1.0),
+                "dc_internal_resistance_ohm": ColExpect("Internal Resistance (Ohm)", 1.0),
+                "ac_internal_resistance_ohm": ColExpect("ACR (Ohm)", 1.0),
+                # NOTE: the four vendor accumulator expectations below disappear when the
+                # accumulator-unmap change (fix/derived-tolerance-and-arbin-accumulators)
+                # merges; drop them during that rebase.
+                "charging_capacity_ah": ColExpect("Charge Capacity (Ah)", 1.0),
+                "discharging_capacity_ah": ColExpect("Discharge Capacity (Ah)", 1.0),
+                "charging_energy_wh": ColExpect("Charge Energy (Wh)", 1.0),
+                "discharging_energy_wh": ColExpect("Discharge Energy (Wh)", 1.0),
+            },
+            null_ok_columns=frozenset({"DC Internal Resistance / ohm", "AC Internal Resistance / ohm"}),
+            known_validity_bugs={
+                "ac_internal_resistance_ohm": "ACR (Ohm) is entirely empty in this dynamic-load export",
+                # Schedule-authored accumulator resets (79 discharge / 1 charge, at scripted
+                # steps); removed along with the accumulator ColExpects at the unmap rebase.
+                "charging_capacity_ah": "Charge Capacity resets at schedule-defined steps",
+                "discharging_capacity_ah": "Discharge Capacity resets at schedule-defined steps",
+                "charging_energy_wh": "Charge Energy resets at schedule-defined steps",
+                "discharging_energy_wh": "Discharge Energy resets at schedule-defined steps",
+            },
+            marks=(
+                pytest.mark.network,
+                pytest.mark.skipif(
+                    pytest.importorskip("fastexcel", reason="fastexcel not installed") is None,
+                    reason="fastexcel not installed",
+                ),
+            ),
         ),
     ),
 ]

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -400,3 +400,41 @@ class TestLoadDumpPlugins:
         dump_plugins({"neware_csv": NEWARE_CSV}, path)
         data = json.loads(path.read_text())
         assert "separator" not in data["neware_csv"]["table_parser"]
+
+
+class TestArbinXlsxDetection:
+    """arbin_xlsx vs neware_xlsx disambiguation on shared .xlsx extension."""
+
+    @staticmethod
+    def _workbook(tmp_path, sheet, headers, name):
+        openpyxl = pytest.importorskip("openpyxl")
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = sheet
+        ws.append(headers)
+        ws.append([1] * len(headers))
+        path = tmp_path / name
+        wb.save(path)
+        return path
+
+    def test_arbin_workbook_detects_arbin_xlsx(self, tmp_path):
+        pytest.importorskip("fastexcel")
+        path = self._workbook(
+            tmp_path,
+            "Channel_1-002",
+            ["Data_Point", "Test_Time(s)", "Voltage(V)", "Current(A)", "Step_Index"],
+            "arbin.xlsx",
+        )
+        plugin_id, _ = detect(path)
+        assert plugin_id == "arbin_xlsx"
+
+    def test_neware_workbook_still_detects_neware_xlsx(self, tmp_path):
+        pytest.importorskip("fastexcel")
+        path = self._workbook(
+            tmp_path,
+            "record",
+            ["Time", "Voltage(V)", "Current(A)", "Step Type"],
+            "neware.xlsx",
+        )
+        plugin_id, _ = detect(path)
+        assert plugin_id == "neware_xlsx"

--- a/tests/unit/test_table_parsers.py
+++ b/tests/unit/test_table_parsers.py
@@ -766,3 +766,18 @@ class TestExcelSheetPattern:
     def test_pattern_mutually_exclusive_with_sheet_id(self):
         with pytest.raises(ValueError, match="mutually exclusive"):
             ExcelParser(sheet_pattern=r"^Channel", sheet_id=1)
+
+    def test_multiple_matching_sheets_raise(self, tmp_path):
+        """A multi-channel workbook must not silently read only the first channel."""
+        openpyxl = pytest.importorskip("openpyxl")
+        pytest.importorskip("fastexcel")
+        wb = openpyxl.Workbook()
+        wb.active.title = "Global_Info"
+        for ch in ("Channel_1-001", "Channel_1-002"):
+            ws = wb.create_sheet(ch)
+            ws.append(["Test_Time(s)", "Voltage(V)"])
+        path = tmp_path / "two_channels.xlsx"
+        wb.save(path)
+        parser = ExcelParser(sheet_pattern=r"^Channel[_-]")
+        with pytest.raises(ValueError, match="multiple sheets match"):
+            parser.read_column_headings(path)

--- a/tests/unit/test_table_parsers.py
+++ b/tests/unit/test_table_parsers.py
@@ -719,3 +719,50 @@ class TestNDAParser:
         nda_path.write_bytes(b"")
         parser = NDAParser()
         assert parser.read_column_headings(nda_path) == ["a", "b"]
+
+
+class TestExcelSheetPattern:
+    """ExcelParser.sheet_pattern: regex-based sheet selection for variable sheet names."""
+
+    @staticmethod
+    def _arbin_workbook(tmp_path):
+        openpyxl = pytest.importorskip("openpyxl")
+        wb = openpyxl.Workbook()
+        gi = wb.active
+        gi.title = "Global_Info"
+        gi.append(["Schedule", "HPPC_test.sdx"])
+        ch = wb.create_sheet("Channel_1-002")
+        ch.append(["Data_Point", "Test_Time(s)", "Voltage(V)", "Current(A)"])
+        ch.append([1, 0.0, 3.6, 0.5])
+        wb.create_sheet("ACIM_chan_1").append(["Frequency", "Zreal", "Zimg"])
+        path = tmp_path / "arbin.xlsx"
+        wb.save(path)
+        return path
+
+    def test_pattern_selects_matching_sheet(self, tmp_path):
+        pytest.importorskip("fastexcel")
+        path = self._arbin_workbook(tmp_path)
+        parser = ExcelParser(sheet_pattern=r"^Channel[_-]")
+        assert parser.read_column_headings(path) == ["Data_Point", "Test_Time(s)", "Voltage(V)", "Current(A)"]
+
+    def test_pattern_skips_non_matching_sheets(self, tmp_path):
+        """Global_Info and ACIM_chan_* must not match the channel pattern."""
+        pytest.importorskip("fastexcel")
+        path = self._arbin_workbook(tmp_path)
+        parser = ExcelParser(sheet_pattern=r"^Channel[_-]")
+        assert "Frequency" not in parser.read_column_headings(path)
+
+    def test_no_matching_sheet_raises_with_sheet_list(self, tmp_path):
+        pytest.importorskip("fastexcel")
+        path = self._arbin_workbook(tmp_path)
+        parser = ExcelParser(sheet_pattern=r"^record$")
+        with pytest.raises(ValueError, match="no sheet matching"):
+            parser.read_column_headings(path)
+
+    def test_pattern_mutually_exclusive_with_sheet_name(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            ExcelParser(sheet_pattern=r"^Channel", sheet_name="record")
+
+    def test_pattern_mutually_exclusive_with_sheet_id(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            ExcelParser(sheet_pattern=r"^Channel", sheet_id=1)


### PR DESCRIPTION
## What

A new `arbin_xlsx` plugin reading the per-channel data sheet of Arbin MITS Excel exports, validated against the Arbin suite in the new Zenodo test-data record (https://doi.org/10.5281/zenodo.21337233), which spans five laboratories, both Arbin header dialects, and both accumulator behaviors.

## Why

Arbin Excel exports exist in the wild and none were readable by bdf: the generic Excel parser expects a fixed sheet name, while Arbin's data-sheet name varies per export (`Channel_1-002`, `Channel-6_1`, `Channel_6_1`, `Channel_1_1` all observed), and older MITS versions use a second header dialect (`Test_Time(s)` vs `Test Time (s)`).

## How

- `ExcelParser` gains `sheet_pattern`: a case-insensitive regex resolved against the workbook's sheet names, mutually exclusive with `sheet_id`/`sheet_name`. `Global_Info`, `ACIM_chan_*` (EIS), and `Statistics*` sheets never match the channel pattern. **Multiple matches raise** (with the sheet list) rather than silently reading the first channel of a multi-channel workbook — mirroring `_read_sheet`'s existing multi-sheet error.
- The shared `ARBIN` normalizer learns the underscore header dialect alongside the existing spaced one, plus two additional `Date_Time` formats observed in real exports (ISO with fractional seconds, slash-ISO).
- `arbin_xlsx` registered; `.xlsx` detection disambiguates from `neware_xlsx` for free — each parser scores 0 when it cannot find its sheet — unit-tested in both directions.
- Bugfix along the way: `ExcelParser.read_column_headings` never resolved URLs to local files (pre-existing; first exercised by these cases).

## Testing

- 8 new unit tests: sheet-pattern selection/exclusion, no-match and **ambiguous-match** errors, validator mutual-exclusion, detection disambiguation both ways (openpyxl-fabricated workbooks; `openpyxl` is a base dependency, `fastexcel` gated by importorskip).
- 3 new network integration cases from the new record: the 39-row OCV micro-fixture (underscore dialect), a capacity test (underscore, no `Data_Point`), and the Melasta dynamic-load export (spaced dialect, multi-sheet with EIS, schedule-resetting accumulators annotated as `known_validity_bugs`).
- **Full network integration suite run locally: 260 passed, 0 failures, 12 xfailed** — specifically confirming the new shared-normalizer synonyms cause no detection or column-resolution change for any existing vendor.
- Full offline suite: 582 unit / 154 integration, green.

## Notes

- **Rebase coupling:** the Melasta case's four accumulator `ColExpect`s and their `known_validity_bugs` entries carry removal comments and drop when `fix/derived-tolerance-and-arbin-accumulators` merges — whichever lands second rebases (trivial, marked in-line).
- Adding the three URLs rotates the warm-cache key on first CI run (expected).
- Out of scope, tracked as follow-ups: `Global_Info` metadata extraction (schedule name / start time — the reset-provenance source), `Wb_1`/`Wb_2` multi-workbook continuation joining (a `Wb_2` file currently reads as a valid-but-partial standalone dataset), ACIM (EIS) sheet ingestion, and a vendor-notes entry that Arbin `Date_Time` is lab-local wall time (the default-UTC warning applies; pass `tz=` for correct `unix_time_second`).
