### PR TITLE
fix(spec): follow dcterms:isReplacedBy when redirecting deprecated columns

### DIFF
--- a/src/bdf/io.py
+++ b/src/bdf/io.py
@@ -183,8 +183,12 @@ def _label_maps() -> tuple[dict[str, str], dict[str, str]]:
 
         target_q = q
         if s.deprecated:
-            base = source_pref.split(" / ", 1)[0].strip().lower()
-            target_q = base_preferred.get(base, q)
+            # isReplacedBy first; base-name heuristic as fallback (see _build_bdf_normalizer).
+            if s.replaced_by and spec.COLUMN_ONTOLOGY.get(s.replaced_by) is not None:
+                target_q = s.replaced_by
+            else:
+                base = source_pref.split(" / ", 1)[0].strip().lower()
+                target_q = base_preferred.get(base, q)
 
         target = getattr(spec.COLUMN_ONTOLOGY, target_q)
         target_pref = target.formatted_label
@@ -323,8 +327,12 @@ def canonicalize_legacy_labels(
         target_q = q
         is_deprecated = s.deprecated
         if s.deprecated:
-            base = pref.split(" / ", 1)[0].strip().lower()
-            target_q = base_preferred.get(base, q)
+            # isReplacedBy first; base-name heuristic as fallback (see _build_bdf_normalizer).
+            if s.replaced_by and spec.COLUMN_ONTOLOGY.get(s.replaced_by) is not None:
+                target_q = s.replaced_by
+            else:
+                base = pref.split(" / ", 1)[0].strip().lower()
+                target_q = base_preferred.get(base, q)
         target_canon = spec.COLUMN_ONTOLOGY[target_q].formatted_label
         target_unit = spec.COLUMN_ONTOLOGY[target_q].unit
         src_unit = s.unit if is_deprecated and s.unit != target_unit else ""

--- a/src/bdf/spec.py
+++ b/src/bdf/spec.py
@@ -323,6 +323,9 @@ class Quantity(BaseModel):
     iri: str
     synonyms: list[str]
     deprecated: bool = False
+    replaced_by: str = ""
+    """mr_name of the non-deprecated replacement (dcterms:isReplacedBy); empty when
+    not deprecated or the ontology carries no link."""
     notation: str = ""
     obligation: str = ""
     definition: str = ""
@@ -447,6 +450,18 @@ class Quantity(BaseModel):
             False,
         )
 
+        # dcterms:isReplacedBy links a deprecated term to its preferred replacement;
+        # the IRI fragment is the replacement's mr_name. Left empty when absent so
+        # consumers fall back to the label base-name heuristic.
+        replaced_by = next(
+            (
+                str(obj).rsplit("#", 1)[-1]
+                for obj in g.objects(subject, URIRef("http://purl.org/dc/terms/isReplacedBy"))
+                if isinstance(obj, URIRef) and str(obj).startswith(ns)
+            ),
+            "",
+        )
+
         alt_labels = _english_literals(g, subject, skos.altLabel)
         notations = _english_literals(g, subject, skos.notation)
         notation = next((s for n in notations if (s := str(n).strip())), mr_name)
@@ -491,6 +506,7 @@ class Quantity(BaseModel):
             notation=notation,
             iri=iri,
             deprecated=deprecated,
+            replaced_by=replaced_by,
             synonyms=synonyms,
             obligation=obligation,
             definition=definition,

--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -1100,8 +1100,14 @@ def _build_bdf_normalizer() -> TableNormalizer:
     for mr_name, q in COLUMN_ONTOLOGY:
         target_mr = mr_name
         if q.deprecated:
-            base = q.formatted_label.split(" / ", 1)[0].strip().lower()
-            target_mr = base_preferred.get(base, mr_name)
+            # Prefer the ontology's explicit dcterms:isReplacedBy link; the label
+            # base-name heuristic only covers unit-only renames (ms -> s) and
+            # silently misses renames like step_capacity_ah -> step_cumulative_capacity_ah.
+            if q.replaced_by and q.replaced_by in TableNormalizer.model_fields:
+                target_mr = q.replaced_by
+            else:
+                base = q.formatted_label.split(" / ", 1)[0].strip().lower()
+                target_mr = base_preferred.get(base, mr_name)
             if target_mr not in TableNormalizer.model_fields:
                 continue
         elif mr_name not in TableNormalizer.model_fields:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -208,3 +208,23 @@ def test_read_returns_table_parser_frame_unchanged(read_mocks: SimpleNamespace, 
     p = tmp_path / "f.csv"
     result, _ = read(p, plugin=read_mocks.plugin, lazy=False)
     assert result is sentinel
+
+
+class TestDeprecatedLabelRedirects:
+    """Load and save paths route deprecated labels via dcterms:isReplacedBy."""
+
+    def test_canonicalize_renames_to_replacement(self):
+        """Regression: step_capacity_ah was renamed to its own deprecated pref label
+        instead of the replacement's."""
+        df = pd.DataFrame({"step_capacity_ah": [0.5], "test_time_second": [0.0]})
+        out, legacy = io.canonicalize_legacy_labels(df)
+        assert "Step Cumulative Capacity / Ah" in out.columns
+        assert "Step Capacity / Ah" not in out.columns
+        assert "step_capacity_ah" in legacy
+
+    def test_label_maps_route_deprecated_notation_to_replacement_pref(self):
+        """The save-path label maps must also honor the replacement link."""
+        _, machine_to_pref = io._label_maps()
+        assert machine_to_pref["step_capacity_ah"] == "Step Cumulative Capacity / Ah"
+        assert machine_to_pref["step_energy_wh"] == "Step Cumulative Energy / Wh"
+        assert machine_to_pref["test_time_millisecond"] == "Test Time / s"

--- a/tests/unit/test_spec_ontology.py
+++ b/tests/unit/test_spec_ontology.py
@@ -955,3 +955,55 @@ class TestFormattedLabel:
         """A literal {unit} placeholder is not substituted when unit is None."""
         q = Quantity(unit=None, label_template="X / {unit}", mr_name="x", iri="x", synonyms=[])
         assert q.formatted_label == "X / {unit}"
+
+
+# ---------------------------------------------------------------------------
+# dcterms:isReplacedBy -> Quantity.replaced_by
+# ---------------------------------------------------------------------------
+
+_REPLACED_BY_TTL = """\
+@prefix : <https://w3id.org/battery-data-alliance/ontology/battery-data-format#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <https://schema.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+:old_thing_ah rdf:type owl:Class ;
+    owl:deprecated "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+    dcterms:isReplacedBy :new_thing_ah ;
+    skos:prefLabel "Old Thing / Ah"@en ;
+    schema:unitCode "A.h" .
+
+:orphan_ms rdf:type owl:Class ;
+    owl:deprecated "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+    skos:prefLabel "Orphan / ms"@en ;
+    schema:unitCode "ms" .
+
+:new_thing_ah rdf:type owl:Class ;
+    skos:prefLabel "New Thing / Ah"@en ;
+    schema:unitCode "A.h" .
+"""
+
+
+def test_replaced_by_extracted_from_isreplacedby_link() -> None:
+    """A deprecated term's dcterms:isReplacedBy fragment lands in Quantity.replaced_by."""
+    onto = ColumnOntology.from_graph(spec._graph_from_bytes(_REPLACED_BY_TTL.encode("utf-8"), format="turtle"))
+    assert onto.old_thing_ah.replaced_by == "new_thing_ah"
+    assert onto.new_thing_ah.replaced_by == ""
+
+
+def test_replaced_by_empty_without_link() -> None:
+    """A deprecated term without an isReplacedBy link keeps replaced_by empty (heuristic fallback)."""
+    onto = ColumnOntology.from_graph(spec._graph_from_bytes(_REPLACED_BY_TTL.encode("utf-8"), format="turtle"))
+    assert onto.orphan_ms.replaced_by == ""
+
+
+def test_every_deprecated_quantity_has_replacement() -> None:
+    """Bundled snapshot invariant: every deprecated term links a non-deprecated replacement."""
+    for mr, q in COLUMN_ONTOLOGY:
+        if not q.deprecated:
+            continue
+        assert q.replaced_by, f"{mr} is deprecated but carries no dcterms:isReplacedBy"
+        target = COLUMN_ONTOLOGY.get(q.replaced_by)
+        assert target is not None and not target.deprecated, f"{mr} -> {q.replaced_by}"

--- a/tests/unit/test_table_normalizers.py
+++ b/tests/unit/test_table_normalizers.py
@@ -1144,3 +1144,34 @@ class TestPybammNormalizer:
         assert (d_cap.filter(current < 0).drop_nulls() <= 0).all()
         # within the charge run net capacity is non-decreasing
         assert (d_cap.filter(current > 0).drop_nulls() >= 0).all()
+
+
+class TestDeprecatedRedirects:
+    """Deprecated on-disk labels must land on their dcterms:isReplacedBy target."""
+
+    def test_renamed_deprecated_columns_survive_read(self):
+        """Regression (#52-era data loss): step_capacity_ah / step_energy_wh headers,
+        whose replacements have a different base name, were silently dropped by the
+        base-name heuristic; the isReplacedBy link routes them correctly."""
+        df = pl.DataFrame(
+            {
+                "test_time_second": [0.0, 1.0],
+                "voltage_volt": [3.7, 3.6],
+                "current_ampere": [0.1, 0.1],
+                "step_capacity_ah": [0.5, 0.6],
+                "step_energy_wh": [1.5, 1.7],
+            }
+        )
+        out = BDF_NORMALIZER.normalize(df, validate=False)
+        assert out["Step Cumulative Capacity / Ah"].to_list() == [0.5, 0.6]
+        assert out["Step Cumulative Energy / Wh"].to_list() == [1.5, 1.7]
+
+    def test_every_deprecated_notation_resolves_to_replacement_label(self):
+        """Exhaustive: each deprecated notation header resolves to its replacement's label."""
+        for mr, q in COLUMN_ONTOLOGY:
+            if not q.deprecated:
+                continue
+            target = COLUMN_ONTOLOGY.get(q.replaced_by)
+            assert target is not None, mr
+            resolved = BDF_NORMALIZER.resolve([q.effective_notation])
+            assert resolved.get(q.replaced_by) is not None, f"{q.effective_notation} did not resolve to {q.replaced_by}"


### PR DESCRIPTION
## What  
`Quantity` gains a `replaced_by` field populated from the ontology's `dcterms:isReplacedBy` links, and the three places that redirect deprecated columns (`_build_bdf_normalizer` on read, `canonicalize_legacy_labels` on load, `_label_maps` on save) now use it, with the existing base-name heuristic kept as fallback for terms without a link.

## Why  
The ontology explicitly declares each deprecated term's replacement, but the Python side ignored those links and relied only on a base-name heuristic. Deprecated columns whose replacement it couldn't derive were silently dropped, i.e. data loss on legacy files. This makes the ontology the source of truth for redirects, as it already is for everything else.

## How  
`replaced_by` is parsed from the bundled snapshot; each redirect site tries it first and falls back to the heuristic. A new invariant test pins the contract going forward: every deprecated term in the bundled snapshot must link a live, non-deprecated replacement, so a future ontology sync that breaks a link fails CI instead of silently regressing.

## Testing  
Unit tests for the parsing (link present, link absent → fallback) and the snapshot invariant; full offline suite green. Verified against the current ontology `main` that all four deprecated terms carry intact links with live targets, so the upcoming 1.3.0 snapshot sync satisfies the invariant.

## Notes  
Behavior change, intended: for files carrying deprecated labels, `bdf.read` now keeps columns it previously dropped, and `bdf.load` renames them to the replacement label (e.g. `Step Capacity / Ah` → `Step Cumulative Capacity / Ah`). Anyone keying on the old buggy output will see the corrected names; changelog entry to follow in the 0.2.0 notes.