### PR TITLE
Expand unit regex

### DIFF
--- a/src/bdf/spec.py
+++ b/src/bdf/spec.py
@@ -187,7 +187,7 @@ def get_unit_conversion(src_unit: str | None, dst_unit: str | None) -> tuple[flo
         scale = round(at_one - at_zero, 15)
         offset = round(at_zero, 15)
         return (scale, offset)
-    except pint.errors.PintError:
+    except (pint.errors.PintError, AssertionError):
         return None
 
 

--- a/src/bdf/spec.py
+++ b/src/bdf/spec.py
@@ -55,6 +55,7 @@ _UNIT_ALIAS = {
     "A.h": "Ah",
     "W.h": "Wh",
     "Ohm": "ohm",
+    "Ω": "ohm",  # 'ohm' character, 'Omega' character already understood by pint
 }
 
 # Bare "C" or "c" is ambiguous (Celsius vs Coulombs). This set lists the BDF

--- a/src/bdf/spec.py
+++ b/src/bdf/spec.py
@@ -167,8 +167,8 @@ def get_unit_conversion(src_unit: str | None, dst_unit: str | None) -> tuple[flo
     Returns:
         Tuple of (scale, offset) for conversion, or None if incompatible.
     """
-    src_bare = (src_unit or "").strip()
-    dst_bare = (dst_unit or "").strip()
+    src_bare = _normalize_unit((src_unit or "").strip())
+    dst_bare = _normalize_unit((dst_unit or "").strip())
     src_is_dim = src_bare in ("", "1")
     dst_is_dim = dst_bare in ("1", "")
     if src_is_dim or dst_is_dim:

--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -26,7 +26,7 @@ _logger = logging.getLogger(__name__)
 
 _DATE_COMPONENT_RE = re.compile(r"%[YymbBdej]")
 _TZ_COMPONENT_RE = re.compile(r"%:?[zZ]")
-_UNIT_CAPTURE = r"([A-Za-z0-9.·/*^%°℃ΩΩµμ⁰¹²³⁴⁵⁶⁷⁸⁹⁻ \-]+)" # omega/ohm and mu/micro are different characters
+_UNIT_CAPTURE = r"([A-Za-z0-9.·/*^%°℃ΩΩµμ⁰¹²³⁴⁵⁶⁷⁸⁹⁻ \-]+)"  # omega/ohm and mu/micro are different characters
 _DST_AMBIGUOUS_STRATEGY = "earliest"
 _DST_NON_EXISTENT_STRATEGY = "null"
 

--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -685,7 +685,7 @@ BASYTEC = TableNormalizer(
         Syn(hdr="Current", assumed=True),
     ),
     temperature_t1_celsius=(
-        Syn(hdr="T1[{unit}]", assumed=True),
+        Syn(hdr="T1[{unit}]"),
         Syn(hdr="T1[°C]"),
         Syn(hdr="Temp[{unit}]", assumed=True),
         Syn(hdr="Temp[°C]", assumed=True),

--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -26,7 +26,7 @@ _logger = logging.getLogger(__name__)
 
 _DATE_COMPONENT_RE = re.compile(r"%[YymbBdej]")
 _TZ_COMPONENT_RE = re.compile(r"%:?[zZ]")
-_UNIT_CAPTURE = r"([A-Za-z0-9./]+)"
+_UNIT_CAPTURE = r"([A-Za-z0-9.·/*^%°℃ΩΩµμ⁰¹²³⁴⁵⁶⁷⁸⁹⁻ \-]+)" # omega/ohm and mu/micro are different characters
 _DST_AMBIGUOUS_STRATEGY = "earliest"
 _DST_NON_EXISTENT_STRATEGY = "null"
 

--- a/tests/unit/test_spec_ontology.py
+++ b/tests/unit/test_spec_ontology.py
@@ -200,6 +200,20 @@ def test_pint_understands_never_propagates_on_pathological_alias() -> None:
         # "Cel" (UCUM unitCode casing) converts with the correct offset
         ("Cel", "K", (1.0, 273.15)),
         ("Cel", "degC", (1.0, 0.0)),
+        # Units with special characters
+        ("℃", "degC", (1.0, 0.0)),
+        ("°C", "degC", (1.0, 0.0)),
+        ("mA*h", "Ah", (1.0e-3, 0.0)),
+        ("mA·h", "Ah", (1.0e-3, 0.0)),
+        ("mA h", "Ah", (1.0e-3, 0.0)),
+        ("mA  h", "Ah", (1.0e-3, 0.0)),
+        ("V s⁻¹", "V/s", (1.0, 0.0)),
+        ("V / s", "V/s", (1.0, 0.0)),
+        ("V s^-1", "V/s", (1.0, 0.0)),
+        ("µA", "A", (1.0e-6, 0.0)),
+        ("μA", "A", (1.0e-6, 0.0)),
+        ("Ω", "ohm", (1.0, 0.0)),
+        ("Ω", "ohm", (1.0, 0.0)),
     ],
 )
 def test_get_unit_conversion(src: str | None, dst: str, expected: tuple[float, float] | None) -> None:


### PR DESCRIPTION
Adds more characters to unit regex:
`·/*^%°℃ΩΩµμ⁰¹²³⁴⁵⁶⁷⁸⁹⁻ \-`

These are mostly natively handled by pint, so we don't need to do much more.

Now we capture units like
`A·h`, `A h`, `A*h`, `V/s`, `V s⁻¹`, `V / s`, `V s^-1`, `℃`, `µA`
which would get missed before

I also add the ohm symbol to unit alias just in case, pint only uses the Omega symbol, which is a different unicode character.

We also now capture a Bayestec temperature column in the existing dataset that was missed before.