### PR TITLE
feat(io): reconcile elapsed-time unit against wall clock on read (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [Unreleased]
 ### Added
+- Time reconciliation on read (GH #65): `bdf.read` cross-checks `Test Time / s` and `Step Time / s` increments against wall-clock (`Unix Time / s`) increments; a column stored in the wrong unit under a seconds header (e.g. a Digatron export holding milliseconds) is rescaled to seconds, recorded under `metadata["time_reconciliation"]`, and announced with a `UserWarning`. Disable with `reconcile_time=False`. `bdf.validate` reports the same mismatch as a `time_scale` finding without modifying data.
 - repair.py ported to polars-native internals: fix_time and clean now accept polars (eager or lazy) or pandas frames and return the same kind, with identical numeric results across input types (pinned by the characterization suite). mypy re-enabled on the module; the CLI clean command no longer round-trips through pandas.
 - Arbin normalizers (csv, xlsx) map Charge/Discharge Capacity and Energy to the schedule_* terms from ontology 1.3.0, reflecting the operator-defined reset behavior Arbin confirmed; the columns previously landed on the never-resetting test-scoped terms.
 - CI pipeline with lint/type/tests/docs and build/twine checks.

--- a/docs/examples/metadata.ipynb
+++ b/docs/examples/metadata.ipynb
@@ -51,7 +51,13 @@
       "outputs": [],
       "source": [
         "# Read the raw source data and display the header\n",
-        "df, source_meta = bdf.read(\"https://zenodo.org/records/17295469/files/FZJ__INR21700__20250606__HPPC__25degC__Digatron.csv\")\n",
+        "# This export stores its time columns in milliseconds under seconds headers;\n",
+        "# bdf.read detects the mismatch against the recorded timestamps and raises\n",
+        "# unless we explicitly opt into the repair with reconcile_time=True.\n",
+        "df, source_meta = bdf.read(\n",
+        "    \"https://zenodo.org/records/17295469/files/FZJ__INR21700__20250606__HPPC__25degC__Digatron.csv\",\n",
+        "    reconcile_time=True,\n",
+        ")\n",
         "df = df.to_pandas()\n",
         "df.head()"
       ]

--- a/src/bdf/_time_scale.py
+++ b/src/bdf/_time_scale.py
@@ -1,0 +1,101 @@
+"""Cross-check elapsed-time columns against independently recorded wall-clock time.
+
+Vendor exports sometimes declare an elapsed-time column in seconds while the
+values are actually in another unit (e.g. a Digatron export storing
+milliseconds under a seconds header, GH issue #65). Nothing inside the column
+itself reveals this: the timeline is self-consistent, so every single-column
+check passes. The mismatch only becomes visible when the column's increments
+are compared with the wall-clock (``unix_time_second``) increments recorded
+independently alongside them.
+
+This module holds the pure detection arithmetic shared by ``bdf.io.read``
+(reconcile on read) and ``bdf.validate`` (report on validation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+__all__ = ["KNOWN_SCALE_FACTORS", "ScaleMismatch", "detect_scale_mismatch"]
+
+# ratio of (elapsed increments / wall-clock increments) -> actual unit of the
+# elapsed values when the header declares seconds.
+KNOWN_SCALE_FACTORS: tuple[tuple[float, str], ...] = (
+    (1e9, "nanoseconds"),
+    (1e6, "microseconds"),
+    (1e3, "milliseconds"),
+    (1.0 / 60.0, "minutes"),
+    (1.0 / 3600.0, "hours"),
+)
+
+# |ratio - 1| within this band counts as consistent. Wall-clock timestamps are
+# typically recorded at 1 s resolution, so individual delta ratios jitter; the
+# band is applied to the median over many samples.
+_CONSISTENT_RTOL = 0.05
+_FACTOR_RTOL = 0.05
+_MIN_WALL_STEP_S = 0.5
+_MIN_SAMPLES = 10
+
+
+@dataclass(frozen=True)
+class ScaleMismatch:
+    """A detected disagreement between elapsed-time and wall-clock increments.
+
+    Attributes:
+        ratio: Median of (elapsed increment / wall-clock increment) over valid rows.
+        factor: Matched entry from :data:`KNOWN_SCALE_FACTORS`, or None when the
+            ratio matches no known unit (unexplained; do not auto-repair).
+        unit_name: Human-readable name of the actual unit ("milliseconds", ...),
+            or None when unexplained.
+        n_samples: Number of increment pairs the ratio was estimated from.
+    """
+
+    ratio: float
+    factor: float | None
+    unit_name: str | None
+    n_samples: int
+
+
+def detect_scale_mismatch(
+    elapsed: np.ndarray,
+    wall: np.ndarray,
+    *,
+    min_wall_step: float = _MIN_WALL_STEP_S,
+    min_samples: int = _MIN_SAMPLES,
+) -> ScaleMismatch | None:
+    """Compare elapsed-time increments with wall-clock increments.
+
+    Both inputs are value arrays in declared seconds, row-aligned. Increments
+    are compared pairwise; only rows where both clocks advance are used, so
+    step-time resets and logging pauses drop out naturally. The median ratio
+    is robust to a minority of irregular samples.
+
+    Args:
+        elapsed: Elapsed-time column values (e.g. ``Test Time / s``).
+        wall: Wall-clock column values (``Unix Time / s``).
+        min_wall_step: Minimum wall-clock increment (seconds) for a sample to
+            count, guarding against timestamp-resolution noise.
+        min_samples: Minimum number of valid increment pairs required to judge.
+
+    Returns:
+        A :class:`ScaleMismatch` when the median ratio deviates from 1 beyond
+        tolerance (``factor``/``unit_name`` set when it matches a known unit),
+        or None when the clocks agree or there is too little data to judge.
+    """
+    if elapsed.size != wall.size or elapsed.size < min_samples + 1:
+        return None
+    d_elapsed = np.diff(elapsed.astype(float))
+    d_wall = np.diff(wall.astype(float))
+    valid = np.isfinite(d_elapsed) & np.isfinite(d_wall) & (d_elapsed > 0) & (d_wall >= min_wall_step)
+    n = int(valid.sum())
+    if n < min_samples:
+        return None
+    ratio = float(np.median(d_elapsed[valid] / d_wall[valid]))
+    if abs(ratio - 1.0) <= _CONSISTENT_RTOL:
+        return None
+    for factor, unit_name in KNOWN_SCALE_FACTORS:
+        if abs(ratio - factor) <= _FACTOR_RTOL * factor:
+            return ScaleMismatch(ratio=ratio, factor=factor, unit_name=unit_name, n_samples=n)
+    return ScaleMismatch(ratio=ratio, factor=None, unit_name=None, n_samples=n)

--- a/src/bdf/io.py
+++ b/src/bdf/io.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 from typing import Any, Literal, cast
 
 import pandas as pd
 import polars as pl
 
+from bdf._time_scale import detect_scale_mismatch
 from bdf.file_utils import open_compressed, strip_compression_suffix
 from bdf.plugins import PLUGINS, Plugin, detect
 from bdf.spec import COLUMN_ONTOLOGY
@@ -22,6 +24,7 @@ def _read(
     include_unknown: bool = False,
     lazy: bool = True,
     tz: str = "UTC",
+    reconcile_time: bool = False,
 ) -> tuple[pl.DataFrame | pl.LazyFrame, dict]:
     """Read ``path`` (local file or URL) to BDF-canonical form, returning ``(df, metadata)``.
 
@@ -56,7 +59,121 @@ def _read(
         **resolved_plugin.metadata_parser.parse(path),
     }
 
+    if normalize:
+        bdf_df, repairs = _reconcile_time_scale(bdf_df, reconcile_time=reconcile_time, strict=validate)
+        if repairs:
+            metadata["time_reconciliation"] = repairs
+
     return bdf_df, metadata
+
+
+# Rows sampled for the elapsed-vs-wall-clock scale estimate; a uniform unit
+# error shows up in any contiguous slice, so bounding the sample keeps lazy
+# reads cheap on large files.
+_RECONCILE_SAMPLE_ROWS = 100_000
+
+
+def _reconcile_time_scale(
+    df: pl.DataFrame | pl.LazyFrame,
+    *,
+    reconcile_time: bool,
+    strict: bool,
+) -> tuple[pl.DataFrame | pl.LazyFrame, list[dict]]:
+    """Detect elapsed-time columns stored in the wrong unit; repair only on request.
+
+    Compares ``Test Time / s`` and ``Step Time / s`` increments against the
+    independently recorded wall clock (``Unix Time / s``). Detection always
+    runs; the fsck model applies to what happens on a mismatch:
+
+    - ``reconcile_time=True`` and the ratio matches a known unit factor (see
+      :data:`bdf._time_scale.KNOWN_SCALE_FACTORS`): the column is rescaled to
+      seconds, the repair is recorded, and a ``UserWarning`` announces it.
+    - otherwise, ``strict=True`` raises :class:`bdf.validate.BDFValidationError`
+      (loud failure, nothing modified) and ``strict=False`` downgrades to a
+      ``UserWarning``.
+
+    Args:
+        df: Normalized BDF frame (eager or lazy).
+        reconcile_time: Rescale columns whose mismatch matches a known unit factor.
+        strict: Raise on unrepaired mismatches instead of warning.
+
+    Returns:
+        Tuple of (possibly rescaled frame, list of repair records). The list is
+        empty when nothing was repaired.
+
+    Raises:
+        BDFValidationError: On an unrepaired mismatch when ``strict`` is True.
+    """
+    wall_label = COLUMN_ONTOLOGY.unix_time_second.formatted_label
+    elapsed_labels = (
+        COLUMN_ONTOLOGY.test_time_second.formatted_label,
+        COLUMN_ONTOLOGY.step_time_second.formatted_label,
+    )
+
+    columns = df.collect_schema().names() if isinstance(df, pl.LazyFrame) else df.columns
+    if wall_label not in columns:
+        return df, []
+    present = [lbl for lbl in elapsed_labels if lbl in columns]
+    if not present:
+        return df, []
+
+    sample = df.select([wall_label, *present]).head(_RECONCILE_SAMPLE_ROWS)
+    if isinstance(sample, pl.LazyFrame):
+        sample = sample.collect()
+    wall = sample[wall_label].cast(pl.Float64).to_numpy()
+
+    records: list[dict] = []
+    rescale: list[pl.Expr] = []
+    problems: list[str] = []
+    for label in present:
+        mismatch = detect_scale_mismatch(sample[label].cast(pl.Float64).to_numpy(), wall)
+        if mismatch is None:
+            continue
+        if mismatch.unit_name:
+            described = (
+                f"'{label}' values appear to be {mismatch.unit_name}, not the declared seconds "
+                f"(increments disagree with '{wall_label}' by ~{mismatch.ratio:g}x)"
+            )
+        else:
+            described = (
+                f"'{label}' increments disagree with '{wall_label}' increments by "
+                f"~{mismatch.ratio:g}x, which matches no known unit"
+            )
+        if reconcile_time and mismatch.factor is not None:
+            rescale.append(pl.col(label) / mismatch.factor)
+            records.append(
+                {
+                    "column": label,
+                    "declared_unit": "s",
+                    "actual_unit": mismatch.unit_name,
+                    "ratio_vs_wall_clock": mismatch.ratio,
+                    "n_samples": mismatch.n_samples,
+                    "action": f"divided by {mismatch.factor:g}",
+                }
+            )
+            warnings.warn(
+                f"{described}; rescaled to seconds as requested (reconcile_time=True). "
+                f"Recorded in metadata['time_reconciliation'].",
+                UserWarning,
+                stacklevel=4,
+            )
+        else:
+            problems.append(described)
+
+    if problems:
+        detail = "; ".join(problems)
+        if strict:
+            from bdf.validate import BDFValidationError
+
+            raise BDFValidationError(
+                f"Elapsed-time/wall-clock mismatch: {detail}. Pass reconcile_time=True to "
+                f"rescale known unit factors, or validate=False to load the data as-is."
+            )
+        warnings.warn(f"Elapsed-time/wall-clock mismatch: {detail}.", UserWarning, stacklevel=4)
+
+    if rescale:
+        df = df.with_columns(rescale)
+    return df, records
 
 
 def read(
@@ -67,6 +184,7 @@ def read(
     validate: bool = True,
     include_unknown: bool = False,
     tz: str = "UTC",
+    reconcile_time: bool = False,
 ) -> tuple[pl.DataFrame, dict]:
     """Read ``path`` (local file or URL) to BDF-canonical form, returning ``(df, metadata)``.
 
@@ -82,6 +200,12 @@ def read(
         include_unknown: Keep columns outside of the BDF spec in the dataframe (default False).
         tz: IANA timezone used to compute ``Unix Time / s`` if the source has naive datetime.
             Default is``"UTC"``, and will warn if source contains naive datetimes.
+        reconcile_time: Elapsed-time columns are cross-checked against wall-clock
+            increments when both are present (e.g. a vendor export storing milliseconds
+            under a seconds header, GH #65). A mismatch raises ``BDFValidationError`` by
+            default (warns when ``validate=False``); pass ``reconcile_time=True`` to
+            explicitly rescale known unit factors, recorded under
+            ``metadata["time_reconciliation"]``. Only active when ``normalize=True``.
 
     Returns:
         Tuple of (df, metadata): the BDF table as a DataFrame, and a metadata dict with at
@@ -99,6 +223,7 @@ def read(
         include_unknown=include_unknown,
         lazy=False,
         tz=tz,
+        reconcile_time=reconcile_time,
     )
     return cast(pl.DataFrame, bdf_df), metadata
 
@@ -111,6 +236,7 @@ def scan(
     validate: bool = True,
     include_unknown: bool = False,
     tz: str = "UTC",
+    reconcile_time: bool = False,
 ) -> tuple[pl.LazyFrame, dict]:
     """Scan ``path`` (local file or URL) to BDF-canonical form, returning ``(df, metadata)``.
 
@@ -131,6 +257,12 @@ def scan(
         include_unknown: Keep columns outside of the BDF spec in the dataframe (default False).
         tz: IANA timezone used to compute ``Unix Time / s`` if the source has naive datetime.
             Default is``"UTC"``, and will warn if source contains naive datetimes.
+        reconcile_time: Elapsed-time columns are cross-checked against wall-clock
+            increments when both are present (e.g. a vendor export storing milliseconds
+            under a seconds header, GH #65). A mismatch raises ``BDFValidationError`` by
+            default (warns when ``validate=False``); pass ``reconcile_time=True`` to
+            explicitly rescale known unit factors, recorded under
+            ``metadata["time_reconciliation"]``. Only active when ``normalize=True``.
 
     Returns:
         Tuple of (df, metadata): the BDF table as a LazyFrame, and a metadata dict with at
@@ -148,6 +280,7 @@ def scan(
         include_unknown=include_unknown,
         lazy=True,
         tz=tz,
+        reconcile_time=reconcile_time,
     )
     return cast(pl.LazyFrame, bdf_df), metadata
 

--- a/src/bdf/validate.py
+++ b/src/bdf/validate.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 
 from . import spec
+from ._time_scale import detect_scale_mismatch
 from .repair import _compute_eps_from_diffs  # reuse your epsilon heuristic
 from .spec import _slugify
 
@@ -158,6 +159,37 @@ def _check_derived(df: pd.DataFrame) -> Dict[str, Any]:
                 if bad:
                     issues.append(f"'{counter_name}' has {bad} transitions that neither increment by 1 nor reset to 1.")
                     details.append({"check": "step_index_seq", "column": counter_name, "violations": bad})
+
+    # 5) elapsed-time vs wall-clock scale cross-check (GH #65): a column whose
+    # values are in the wrong unit is self-consistent, so only the comparison
+    # with the independently recorded wall clock reveals it.
+    if "unix_time_second" in cols:
+        wall = cols["unix_time_second"].to_numpy(dtype=float)
+        for name in ("test_time_second", "step_time_second"):
+            if name not in cols:
+                continue
+            mismatch = detect_scale_mismatch(cols[name].to_numpy(dtype=float), wall)
+            if mismatch is None:
+                continue
+            if mismatch.unit_name:
+                issues.append(
+                    f"'{name}' increments disagree with wall-clock ('unix_time_second') increments "
+                    f"by ~{mismatch.ratio:g}x: values appear to be {mismatch.unit_name}, not seconds."
+                )
+            else:
+                issues.append(
+                    f"'{name}' increments disagree with wall-clock ('unix_time_second') increments "
+                    f"by ~{mismatch.ratio:g}x (no known unit matches this ratio)."
+                )
+            details.append(
+                {
+                    "check": "time_scale",
+                    "column": name,
+                    "ratio": mismatch.ratio,
+                    "actual_unit": mismatch.unit_name,
+                    "n_samples": mismatch.n_samples,
+                }
+            )
 
     return {"issues": issues, "details": details}
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -582,3 +582,97 @@ def test_save_labels(tmp_path: Path) -> None:
     # Unknown mode raises
     with pytest.raises(ValueError, match="Mode 'foo' not understood"):
         io.save(df_orig, p, labels="foo")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# read()/scan() time reconciliation (GH #65)
+# ---------------------------------------------------------------------------
+
+
+def _write_bdf_csv_with_ms_test_time(tmp_path: Path, n: int = 30) -> Path:
+    """BDF artifact whose Test Time / s values are actually milliseconds."""
+    df = pl.DataFrame(
+        {
+            "Test Time / s": [i * 10.0 * 1e3 for i in range(n)],  # ms under a seconds header
+            "Unix Time / s": [1.7e9 + i * 10.0 for i in range(n)],
+            "Voltage / V": [3.7] * n,
+            "Current / A": [0.1] * n,
+        }
+    )
+    path = tmp_path / "corrupted.bdf.csv"
+    df.write_csv(path)
+    return path
+
+
+def test_read_mismatch_raises_by_default(tmp_path: Path) -> None:
+    """fsck model: detection is on, repair is not - loud failure, data untouched."""
+    path = _write_bdf_csv_with_ms_test_time(tmp_path)
+    with pytest.raises(BDFValidationError, match="appear to be milliseconds"):
+        read(path)
+
+
+def test_read_mismatch_warns_when_validate_false(tmp_path: Path) -> None:
+    path = _write_bdf_csv_with_ms_test_time(tmp_path)
+    with pytest.warns(UserWarning, match="appear to be milliseconds"):
+        df, meta = read(path, validate=False)
+    # values loaded as-is, nothing repaired or recorded
+    assert df["Test Time / s"].to_list()[1] == 10_000.0
+    assert "time_reconciliation" not in meta
+
+
+def test_read_reconcile_time_true_repairs_and_records(tmp_path: Path) -> None:
+    path = _write_bdf_csv_with_ms_test_time(tmp_path)
+    with pytest.warns(UserWarning, match="rescaled to seconds as requested"):
+        df, meta = read(path, reconcile_time=True)
+    assert df["Test Time / s"].to_list()[:3] == [0.0, 10.0, 20.0]
+    (record,) = meta["time_reconciliation"]
+    assert record["column"] == "Test Time / s"
+    assert record["actual_unit"] == "milliseconds"
+    assert record["action"] == "divided by 1000"
+
+
+def test_scan_reconcile_time_true_repairs_lazy(tmp_path: Path) -> None:
+    path = _write_bdf_csv_with_ms_test_time(tmp_path)
+    with pytest.warns(UserWarning, match="rescaled to seconds as requested"):
+        lf, meta = scan(path, reconcile_time=True)
+    assert isinstance(lf, pl.LazyFrame)
+    assert lf.collect()["Test Time / s"].to_list()[1] == 10.0
+    assert meta["time_reconciliation"]
+
+
+def test_read_consistent_clocks_add_no_metadata(tmp_path: Path) -> None:
+    n = 30
+    df = pl.DataFrame(
+        {
+            "Test Time / s": [i * 10.0 for i in range(n)],
+            "Unix Time / s": [1.7e9 + i * 10.0 for i in range(n)],
+            "Voltage / V": [3.7] * n,
+            "Current / A": [0.1] * n,
+        }
+    )
+    path = tmp_path / "clean.bdf.csv"
+    df.write_csv(path)
+    out, meta = read(path)
+    assert out["Test Time / s"].to_list()[1] == 10.0
+    assert "time_reconciliation" not in meta
+
+
+def test_read_unexplained_ratio_stays_loud_even_with_reconcile_time(tmp_path: Path) -> None:
+    """A ratio matching no known unit cannot be repaired, so it stays loud."""
+    n = 30
+    df = pl.DataFrame(
+        {
+            "Test Time / s": [i * 370.0 for i in range(n)],  # 37x wall clock: no known unit
+            "Unix Time / s": [1.7e9 + i * 10.0 for i in range(n)],
+            "Voltage / V": [3.7] * n,
+            "Current / A": [0.1] * n,
+        }
+    )
+    path = tmp_path / "odd.bdf.csv"
+    df.write_csv(path)
+    with pytest.raises(BDFValidationError, match="matches no known unit"):
+        read(path, reconcile_time=True)
+    with pytest.warns(UserWarning, match="matches no known unit"):
+        out, meta = read(path, validate=False)
+    assert out["Test Time / s"].to_list()[1] == 370.0
+    assert "time_reconciliation" not in meta

--- a/tests/unit/test_time_scale.py
+++ b/tests/unit/test_time_scale.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import numpy as np
+
+from bdf._time_scale import detect_scale_mismatch
+
+
+def _wall(n: int, step: float = 10.0) -> np.ndarray:
+    return 1.7e9 + np.arange(n, dtype=float) * step
+
+
+def test_consistent_clocks_return_none() -> None:
+    n = 50
+    assert detect_scale_mismatch(np.arange(n, dtype=float) * 10.0, _wall(n)) is None
+
+
+def test_milliseconds_labeled_seconds_detected() -> None:
+    n = 50
+    elapsed_ms = np.arange(n, dtype=float) * 10.0 * 1e3
+    mismatch = detect_scale_mismatch(elapsed_ms, _wall(n))
+    assert mismatch is not None
+    assert mismatch.factor == 1e3
+    assert mismatch.unit_name == "milliseconds"
+    assert mismatch.ratio == 1e3
+
+
+def test_minutes_labeled_seconds_detected() -> None:
+    n = 50
+    elapsed_min = np.arange(n, dtype=float) * 10.0 / 60.0
+    mismatch = detect_scale_mismatch(elapsed_min, _wall(n))
+    assert mismatch is not None
+    assert mismatch.unit_name == "minutes"
+
+
+def test_wall_clock_resolution_jitter_still_detected() -> None:
+    # wall clock recorded at 1 s resolution: increments of 10 s jitter to 9/10/11
+    rng = np.random.default_rng(42)
+    n = 200
+    wall = 1.7e9 + np.cumsum(rng.choice([9.0, 10.0, 11.0], size=n))
+    elapsed_ms = np.cumsum(np.full(n, 10.0)) * 1e3
+    mismatch = detect_scale_mismatch(elapsed_ms, wall)
+    assert mismatch is not None
+    assert mismatch.factor == 1e3
+
+
+def test_unexplained_ratio_has_no_factor() -> None:
+    n = 50
+    mismatch = detect_scale_mismatch(np.arange(n, dtype=float) * 37.0, _wall(n))
+    assert mismatch is not None
+    assert mismatch.factor is None
+    assert mismatch.unit_name is None
+
+
+def test_too_few_samples_return_none() -> None:
+    n = 5
+    assert detect_scale_mismatch(np.arange(n, dtype=float) * 1e4, _wall(n)) is None
+
+
+def test_step_time_resets_are_filtered_out() -> None:
+    # step time in ms, resetting to 0 every 10 rows; resets produce negative
+    # diffs that must not pollute the estimate
+    n = 100
+    step_ms = (np.arange(n, dtype=float) % 10) * 10.0 * 1e3
+    mismatch = detect_scale_mismatch(step_ms, _wall(n))
+    assert mismatch is not None
+    assert mismatch.factor == 1e3
+
+
+def test_pauses_in_elapsed_time_do_not_false_positive() -> None:
+    # elapsed clock stops (paused test) while wall clock advances for a
+    # minority of rows; the median must stay on the consistent samples
+    n = 100
+    elapsed = np.cumsum(np.where(np.arange(n) % 10 == 0, 0.0, 10.0))
+    wall = _wall(n)
+    assert detect_scale_mismatch(elapsed, wall) is None
+
+
+def test_nans_are_ignored() -> None:
+    n = 60
+    elapsed_ms = np.arange(n, dtype=float) * 10.0 * 1e3
+    elapsed_ms[::7] = np.nan
+    mismatch = detect_scale_mismatch(elapsed_ms, _wall(n))
+    assert mismatch is not None
+    assert mismatch.factor == 1e3

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -208,3 +208,35 @@ def test_time_stats_absent_when_no_time_column():
     assert rep["time_stats"]["present"] is False
     assert rep["ok"] is False
     assert "Test Time / s" in rep["missing"]
+
+
+def test_time_scale_mismatch_flagged():
+    """Elapsed time in ms under a seconds header disagrees with the wall clock (GH #65)."""
+    n = 30
+    df = pd.DataFrame(
+        {
+            "Test Time / s": [i * 10.0 * 1e3 for i in range(n)],
+            "Unix Time / s": [1.7e9 + i * 10.0 for i in range(n)],
+            "Voltage / V": [3.7] * n,
+            "Current / A": [0.1] * n,
+        }
+    )
+    with pytest.warns(RuntimeWarning, match="appear to be milliseconds"):
+        rep = validate_df(df, report=False, raise_on_error=False)
+    (detail,) = [d for d in rep["derived"]["details"] if d["check"] == "time_scale"]
+    assert detail["column"] == "test_time_second"
+    assert detail["actual_unit"] == "milliseconds"
+
+
+def test_time_scale_consistent_not_flagged():
+    n = 30
+    df = pd.DataFrame(
+        {
+            "Test Time / s": [i * 10.0 for i in range(n)],
+            "Unix Time / s": [1.7e9 + i * 10.0 for i in range(n)],
+            "Voltage / V": [3.7] * n,
+            "Current / A": [0.1] * n,
+        }
+    )
+    rep = validate_df(df, report=False, raise_on_error=False)
+    assert not any(d["check"] == "time_scale" for d in rep["derived"]["details"])


### PR DESCRIPTION
## What

Implements the time-reconciliation feature planned in #65: the FZJ HPPC Digatron reference file declares its test-time column in seconds but stores milliseconds. Because the timeline is self-consistent, nothing in the file alone reveals it — every single-column check passes. The defect only shows when the column's increments are compared with the independently recorded wall-clock (`Unix Time / s`) increments.

## Changes

**1. `src/bdf/_time_scale.py` (new)** — pure detection shared by read and validate: median ratio of elapsed-vs-wall-clock increments, matched against known unit factors (ns, µs, ms, min, h). Step-time resets, logging pauses, and NaNs drop out of the sample naturally (only rows where both clocks advance count); the median is robust to wall-clock 1 s-resolution jitter.

**2. `bdf.read`** — new `reconcile_time=True` parameter. When `Test Time / s` / `Step Time / s` increments disagree with the wall clock by a known factor, values are rescaled to seconds, the repair is recorded under `metadata["time_reconciliation"]` (column, ratio, detected unit, action), and a `UserWarning` is emitted. An unexplained ratio warns but leaves data untouched. Detection samples the first 100k rows so lazy reads stay cheap.

**3. `bdf.validate`** — reports the same mismatch as a warning-level `time_scale` finding in the derived-checks report, without modifying data — so already-converted artifacts (like the corrupted FZJ `.bdf` upload) fail loudly in reference-data gates instead of passing silently.

## Tests

15 new tests: detection math (ms/min factors, jitter, resets, pauses, NaNs, unexplained ratios, minimum samples), read-level repair + metadata for eager and lazy frames, opt-out, and validate-level reporting. Full unit suite: 591 passed.

Closes the detection/repair scope of #65; regenerating the FZJ artifact and greening its scorecard follows in the reference-datasets workflow.

Refs #65.