### PR TITLE
refactor: consolidate duplicated utilities; route column labels through the spec

### DIFF
--- a/src/bdf/__init__.py
+++ b/src/bdf/__init__.py
@@ -108,11 +108,9 @@ if _enable_short_warnings():
 # small helpers
 # -------------------------------
 def _is_url(x: str) -> bool:
-    try:
-        u = urlparse(str(x))
-        return u.scheme in ("http", "https") and bool(u.netloc)
-    except Exception:
-        return False
+    from .file_utils import is_url
+
+    return is_url(str(x))
 
 
 def _resolve_source(
@@ -164,8 +162,9 @@ def _default_ingest_cache_dir() -> Path:
 
 
 def _ensure_dir(path: Path) -> Path:
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    from .file_utils import ensure_dir
+
+    return ensure_dir(path)
 
 
 def _parse_github_tree(url: str) -> tuple[str, str, str, str] | None:

--- a/src/bdf/__init__.py
+++ b/src/bdf/__init__.py
@@ -7,11 +7,11 @@ import warnings
 # mypy: ignore-errors
 from pathlib import Path
 from typing import Any, Literal, Optional
-from urllib.parse import urlparse
 
 import pandas as pd
 
 # light imports that never cause cycles
+from .file_utils import ensure_dir as _ensure_dir, is_url as _is_url
 from .io import read, save, scan  # spec-driven reader/serializer (the public read()/scan())
 from .plugins import detect  # spec-driven detection -> (plugin_id, Plugin)
 from .repair import CleanReport, clean  # public cleaning helpers
@@ -107,12 +107,6 @@ if _enable_short_warnings():
 # -------------------------------
 # small helpers
 # -------------------------------
-def _is_url(x: str) -> bool:
-    from .file_utils import is_url
-
-    return is_url(str(x))
-
-
 def _resolve_source(
     source: str | Path,
     *,
@@ -159,12 +153,6 @@ def _default_ingest_cache_dir() -> Path:
     if env:
         return Path(env).expanduser().resolve()
     return Path.home() / ".bdf" / "crawl"
-
-
-def _ensure_dir(path: Path) -> Path:
-    from .file_utils import ensure_dir
-
-    return ensure_dir(path)
 
 
 def _parse_github_tree(url: str) -> tuple[str, str, str, str] | None:

--- a/src/bdf/_explore.py
+++ b/src/bdf/_explore.py
@@ -7,6 +7,9 @@ import pandas as pd
 
 from . import spec
 
+X_DEFAULT = spec.COLUMN_ONTOLOGY.test_time_second.formatted_label
+Y_DEFAULT = spec.COLUMN_ONTOLOGY.voltage_volt.formatted_label
+
 
 def _label_with_unit(name: str, unit: str) -> str:
     base = name.split(" / ", 1)[0].strip() if " / " in name else name
@@ -169,8 +172,8 @@ def _plot_plotly(
 def explore(
     df: pd.DataFrame,
     *,
-    xdata: str = "Test Time / s",
-    ydata: str | Iterable[str] = "Voltage / V",
+    xdata: str = X_DEFAULT,
+    ydata: str | Iterable[str] = Y_DEFAULT,
     yydata: Optional[str | Iterable[str]] = None,
     xunit: Optional[str] = None,
     yunit: Optional[str] = None,

--- a/src/bdf/_explore.py
+++ b/src/bdf/_explore.py
@@ -6,9 +6,7 @@ from typing import Optional
 import pandas as pd
 
 from . import spec
-
-X_DEFAULT = spec.COLUMN_ONTOLOGY.test_time_second.formatted_label
-Y_DEFAULT = spec.COLUMN_ONTOLOGY.voltage_volt.formatted_label
+from .visualize import X_DEFAULT, Y_DEFAULT
 
 
 def _label_with_unit(name: str, unit: str) -> str:

--- a/src/bdf/cli.py
+++ b/src/bdf/cli.py
@@ -15,8 +15,8 @@ from . import (
 )
 from .io import read, save
 from .metadata import Creator, Dataset, RelatedIdentifier, save_jsonld
-from .repair import clean as clean_bdf
-from .visualize import plot as line_plot
+from .repair import DEFAULT_OUTLIER_COLS, clean as clean_bdf
+from .visualize import X_DEFAULT, Y_DEFAULT, plot as line_plot
 
 app = typer.Typer(help="Battery Data Format utilities")
 
@@ -188,7 +188,7 @@ def clean(
     time_fix: str = typer.Option("segment", help="segment|sort|drop|none"),
     outlier: str = typer.Option("none", help="none|drop|clip|interp"),
     z: float = typer.Option(8.0, help="Robust z threshold for outliers"),
-    col: List[str] = typer.Option(["Voltage / V", "Current / A"], help="Columns to clean for outliers"),
+    col: List[str] = typer.Option(list(DEFAULT_OUTLIER_COLS), help="Columns to clean for outliers"),
 ):
     """
     Clean a dataset by fixing non-monotonic time and removing/repairing outliers.
@@ -308,8 +308,8 @@ def convert(
 @app.command()
 def plot(
     path: str,
-    xdata: str = typer.Option("Test Time / s", help="BDF column for x-axis"),
-    ydata: List[str] = typer.Option(["Voltage / V"], help="One or more BDF columns for y-axis"),
+    xdata: str = typer.Option(X_DEFAULT, help="BDF column for x-axis"),
+    ydata: List[str] = typer.Option([Y_DEFAULT], help="One or more BDF columns for y-axis"),
     save: Optional[str] = typer.Option(None, "--save", "-s", help="Save figure to file"),
     show: bool = typer.Option(False, "--show/--no-show", help="Display window"),
     as_: Optional[str] = typer.Option(None, "--as", help="Force a specific plugin id (e.g., biologic_mpt)"),

--- a/src/bdf/file_utils.py
+++ b/src/bdf/file_utils.py
@@ -171,6 +171,10 @@ def open_compressed(path: Path) -> Any:
 
         return pa.output_stream(str(path), compression="zstd")
     raise ValueError(f"Unsupported compression: {comp}")
+def ensure_dir(path: Path) -> Path:
+    """Create ``path`` (and parents) if missing and return it."""
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 _BOM = b"\xef\xbb\xbf"

--- a/src/bdf/file_utils.py
+++ b/src/bdf/file_utils.py
@@ -171,6 +171,8 @@ def open_compressed(path: Path) -> Any:
 
         return pa.output_stream(str(path), compression="zstd")
     raise ValueError(f"Unsupported compression: {comp}")
+
+
 def ensure_dir(path: Path) -> Path:
     """Create ``path`` (and parents) if missing and return it."""
     path.mkdir(parents=True, exist_ok=True)

--- a/src/bdf/registry_ld.py
+++ b/src/bdf/registry_ld.py
@@ -12,6 +12,8 @@ from urllib.parse import urlparse
 
 import requests
 
+from .file_utils import ensure_dir as _ensure_dir, is_url as _is_url
+
 _GRAPH_CACHE: dict[str, Any] = {}
 
 
@@ -88,19 +90,6 @@ def _registry_key_from_url(url: str) -> Optional[str]:
         prefix = prefix[:-1]
     key_parts = prefix + [stem] if prefix else [stem]
     return "/".join(key_parts).lower()
-
-
-def _ensure_dir(path: Path) -> Path:
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def _is_url(value: str) -> bool:
-    try:
-        parsed = urlparse(value)
-    except Exception:
-        return False
-    return parsed.scheme in {"http", "https"}
 
 
 def _parse_github_tree(url: str) -> Optional[tuple[str, str, str, str]]:

--- a/src/bdf/repair.py
+++ b/src/bdf/repair.py
@@ -13,8 +13,13 @@ try:
 except Exception:
     sps = None  # type: ignore
 
-TIME_COL = "Test Time / s"
-DEFAULT_OUTLIER_COLS = ("Voltage / V", "Current / A")
+from . import spec
+
+TIME_COL = spec.COLUMN_ONTOLOGY.test_time_second.formatted_label
+DEFAULT_OUTLIER_COLS = (
+    spec.COLUMN_ONTOLOGY.voltage_volt.formatted_label,
+    spec.COLUMN_ONTOLOGY.current_ampere.formatted_label,
+)
 
 __all__ = ["fix_time", "clean", "CleanReport"]
 

--- a/src/bdf/validate.py
+++ b/src/bdf/validate.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import warnings
 from typing import Any, Dict, List
 
@@ -215,9 +214,10 @@ def _collect_report(df: pd.DataFrame) -> Dict[str, Any]:
     missing: List[str] = [c for c in REQUIRED if c not in canonical_present]
 
     # --- time monotonicity (warning-level) ---
+    time_label = spec.COLUMN_ONTOLOGY.test_time_second.formatted_label
     time_stats: Dict[str, Any] = {"present": False, "monotonic": True, "violations": 0, "min_drop": 0.0}
-    if "Test Time / s" in df.columns:
-        s = pd.to_numeric(df["Test Time / s"], errors="coerce")
+    if time_label in df.columns:
+        s = pd.to_numeric(df[time_label], errors="coerce")
         d = s.diff()
         # robust threshold (same idea as clean.py)
         eps = _compute_eps_from_diffs(d.fillna(0.0).to_numpy())
@@ -263,7 +263,7 @@ def _print_report(rep: Dict[str, Any]) -> None:
     ts = rep.get("time_stats", {})
     if ts.get("present") and not ts.get("monotonic", True):
         print(
-            f"   ⚠️ Non-monotonic 'Test Time / s': "
+            f"   ⚠️ Non-monotonic '{spec.COLUMN_ONTOLOGY.test_time_second.formatted_label}': "
             f"{ts['violations']} drops (min Δ = {ts['min_drop']:.6g} s, eps≈{ts['epsilon']:.6g})."
         )
         print("      Suggestion: bdf.clean(df, time_fix='segment') or bdf.repair.fix_time(df, method='auto').")
@@ -285,7 +285,8 @@ def validate_df(
     ts = rep.get("time_stats", {})
     if ts.get("present") and not ts.get("monotonic", True):
         warnings.warn(
-            f"Non-monotonic 'Test Time / s' detected: {ts['violations']} drops "
+            f"Non-monotonic '{spec.COLUMN_ONTOLOGY.test_time_second.formatted_label}' detected: "
+            f"{ts['violations']} drops "
             f"(min Δ = {ts['min_drop']:.6g} s). Consider bdf.repair.fix_time(...).",
             RuntimeWarning,
             stacklevel=2,

--- a/src/bdf/validate.py
+++ b/src/bdf/validate.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from . import spec
 from .repair import _compute_eps_from_diffs  # reuse your epsilon heuristic
+from .spec import _slugify
 
 __all__ = ["BDFValidationError", "validate_df"]
 
@@ -18,13 +19,6 @@ OPTIONAL = spec.COLUMN_ONTOLOGY.optional_labels()
 
 class BDFValidationError(Exception):
     """Raised when a DataFrame fails BDF validation."""
-
-
-_SLUG = re.compile(r"[^a-z0-9]+")
-
-
-def _slugify(text: str) -> str:
-    return _SLUG.sub("-", text.lower()).strip("-")
 
 
 # Algebraic identities the ontology defines via prov:wasDerivedFrom:

--- a/src/bdf/visualize.py
+++ b/src/bdf/visualize.py
@@ -8,8 +8,8 @@ import pandas as pd
 
 from bdf import spec
 
-X_DEFAULT = "Test Time / s"
-Y_DEFAULT = "Voltage / V"
+X_DEFAULT = spec.COLUMN_ONTOLOGY.test_time_second.formatted_label
+Y_DEFAULT = spec.COLUMN_ONTOLOGY.voltage_volt.formatted_label
 
 # ---------- helpers ----------
 


### PR DESCRIPTION
## What

First two steps of the edge-consistency plan (precursor to the `__init__.py` split; supersedes part of the motivation behind #11/#14). Behavior-neutral by construction — values are identical, call sites unchanged.

**Commit 1 — single owners for duplicated utilities.** Four copies of the http(s)-URL check (`__init__`, `registry_ld`, `file_utils`, `io`), three of the slug algorithm (`spec`, `validate`, `io._legacy_slugify`), and two of `ensure_dir` existed with no clear owner. Now: `spec._slugify` is the only slug implementation (it defines the slugs the synonym index is keyed by), `file_utils` owns `is_url` (already public there) and gains `ensure_dir`; everyone else imports.

**Commit 2 — spec-driven column labels.** `repair`, `validate`, `cli`, `visualize`, and `_explore` hardcoded `"Test Time / s"` / `"Voltage / V"` / `"Current / A"` — bypassing the ontology that owns those labels and contradicting the README's "documentation, code, and semantics cannot disagree" guarantee. They now derive from `COLUMN_ONTOLOGY.<quantity>.formatted_label`. A label rename in an ontology release now propagates everywhere from one place.

## Tests

Full unit suite green (575 passed), all pre-commit hooks pass. No new tests: no new behavior — the existing suite pins the label values transitively.