### PR TITLE
docs: pre-0.2.0 sweep — fix PyPI name in notebooks, complete API reference

### DIFF
--- a/docs/examples/registry.ipynb
+++ b/docs/examples/registry.ipynb
@@ -18,7 +18,7 @@
       "source": [
         "## Setup\n",
         "\n",
-        "Install BDF first: `pip install bdf`.\n"
+        "Install BDF first: `pip install batterydf`.\n"
       ]
     },
     {

--- a/docs/examples/visualization.ipynb
+++ b/docs/examples/visualization.ipynb
@@ -95,7 +95,7 @@
         "Use `bdf.explore` for interactive plots. Choose a backend:\n",
         "\n",
         "- `backend=\"plotly\"` (supported by default)\n",
-        "- `backend=\"bokeh\"` (requires `pip install bdf[hvplot]`)\n",
+        "- `backend=\"bokeh\"` (requires `pip install batterydf[hvplot]`)\n",
         "\n"
       ]
     },

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -31,6 +31,7 @@ Python API
    bdf.explore
    bdf.detect
    bdf.ingest
+   bdf.templates
    bdf.datasets
    bdf.load_registry
    bdf.get_entry


### PR DESCRIPTION
## What

Graham's 0.2.0 item 4 ("lots of docs still referring to the old methods — quick sweep before release"). Good news: a full audit of `docs/*.rst`, all 14 example notebooks, `CONTRIBUTING.md`, CLI help text, and source docstrings found that #46 already removed the legacy-method references. Only three confirmed-stale items remained:

- `docs/examples/visualization.ipynb`: `pip install bdf[hvplot]` → `pip install batterydf[hvplot]` (PyPI name is `batterydf`; import stays `bdf`)
- `docs/examples/registry.ipynb`: `pip install bdf` → `pip install batterydf`
- `docs/reference.rst`: `bdf.templates` is public API but was missing from the autosummary

Pairs with #69 (README fixes). Note: the reference page will need another touch when the read/scan API decision lands — deliberately not pre-empting that here.

## Verified

Everything else checked out: no references to removed modules (data_sources/normalize/units/detect/time), all documented API calls exist, install instructions in get_started.rst and README already correct.