### PR TITLE
`read` warn when converting legacy columns

### DIFF
--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -56,6 +56,8 @@ class Syn(BaseModel):
     """True when no real-file sample exercises this synonym (see test_synonym_coverage)."""
     source_unit: str | None = None
     """Fixed source unit for exact, non-templated aliases."""
+    legacy: bool = False
+    """Raise a warning that this column is legacy and has been converted."""
 
     @model_validator(mode="before")
     @classmethod
@@ -130,6 +132,7 @@ class ResolvedColumn(BaseModel):
     datetime_fmts: tuple[str, ...] = Field(
         default=(), description="Datetime format strings for parsing timestamp columns."
     )
+    legacy: bool = False  # Resolved from a legacy column, warn user
 
     @classmethod
     def from_bdf_label(cls, bdf_label_key: str, src_header: str) -> tuple[str, ResolvedColumn]:
@@ -197,6 +200,7 @@ class ResolvedColumn(BaseModel):
                         source_header=header,
                         scale=scale,
                         offset=offset,
+                        legacy=syn.legacy,
                     )
         return None
 
@@ -570,6 +574,19 @@ class TableNormalizer(BaseModel):
 
         if not include_optional:
             resolved = {mr: r for mr, r in resolved.items() if getattr(COLUMN_ONTOLOGY, mr).required}
+
+        legacy_pairs = [
+            (rc.source_header, getattr(COLUMN_ONTOLOGY, mr_name).formatted_label)
+            for mr_name, rc in resolved.items()
+            if rc.legacy
+        ]
+        if legacy_pairs:
+            detail = ", ".join(f"{old!r} -> {new!r}" for old, new in legacy_pairs)
+            warnings.warn(
+                f"Legacy BDF column labels detected and normalized to preferred labels: {detail}",
+                UserWarning,
+                stacklevel=3,
+            )
 
         unix_rc = resolved.get("unix_time_second")
         if unix_rc is not None and unix_rc.datetime_fmts and tz == "UTC":
@@ -1113,8 +1130,8 @@ def _build_bdf_normalizer() -> TableNormalizer:
         elif mr_name not in TableNormalizer.model_fields:
             continue
 
-        _append(target_mr, Syn(hdr=q.label_template))
-        _append(target_mr, Syn(hdr=q.effective_notation, source_unit=q.unit))
+        _append(target_mr, Syn(hdr=q.label_template, legacy=q.deprecated))
+        _append(target_mr, Syn(hdr=q.effective_notation, source_unit=q.unit, legacy=q.deprecated))
     return TableNormalizer(**kwargs)
 
 

--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -1114,24 +1114,32 @@ def _build_bdf_normalizer() -> TableNormalizer:
         if syn not in existing:
             kwargs[target_mr] = (*existing, syn)
 
+    # Append synonyms to TableNormalizer
+    # Append the deprecated quantities first, so their concrete synonyms
+    # (e.g. "Test Time / ms") take priority over generic templates (e.g.
+    # "Time Time / {unit}"), and deprecation warnings get raised correctly.
     for mr_name, q in COLUMN_ONTOLOGY:
-        target_mr = mr_name
-        if q.deprecated:
-            # Prefer the ontology's explicit dcterms:isReplacedBy link; the label
-            # base-name heuristic only covers unit-only renames (ms -> s) and
-            # silently misses renames like step_capacity_ah -> step_cumulative_capacity_ah.
-            if q.replaced_by and q.replaced_by in TableNormalizer.model_fields:
-                target_mr = q.replaced_by
-            else:
-                base = q.formatted_label.split(" / ", 1)[0].strip().lower()
-                target_mr = base_preferred.get(base, mr_name)
-            if target_mr not in TableNormalizer.model_fields:
-                continue
-        elif mr_name not in TableNormalizer.model_fields:
+        if not q.deprecated:
+            continue
+        # Prefer the ontology's explicit dcterms:isReplacedBy link
+        if q.replaced_by and q.replaced_by in TableNormalizer.model_fields:
+            target_mr = q.replaced_by
+        else:
+            base = q.formatted_label.split(" / ", 1)[0].strip().lower()
+            target_mr = base_preferred.get(base, mr_name)
+        if target_mr not in TableNormalizer.model_fields:
             continue
 
-        _append(target_mr, Syn(hdr=q.label_template, legacy=q.deprecated))
-        _append(target_mr, Syn(hdr=q.effective_notation, source_unit=q.unit, legacy=q.deprecated))
+        # Use formatted_label for deprecated terms, not a generic template
+        _append(target_mr, Syn(hdr=q.formatted_label, source_unit=q.unit, legacy=True))
+        _append(target_mr, Syn(hdr=q.effective_notation, source_unit=q.unit, legacy=True))
+
+    # Then append all non-deprecated synonyms
+    for mr_name, q in COLUMN_ONTOLOGY:
+        if q.deprecated or mr_name not in TableNormalizer.model_fields:
+            continue
+        _append(mr_name, Syn(hdr=q.label_template, legacy=False))
+        _append(mr_name, Syn(hdr=q.effective_notation, source_unit=q.unit, legacy=False))
     return TableNormalizer(**kwargs)
 
 

--- a/tests/unit/test_table_normalizers.py
+++ b/tests/unit/test_table_normalizers.py
@@ -930,6 +930,19 @@ class TestBDFNormalizer:
         assert out["Test Time / s"][0] == pytest.approx(1.5)
         assert out.columns == ["Test Time / s", "Voltage / V", "Current / A"]
 
+    def test_bdf_normalizer_warns_for_legacy_cols(self):
+        df = pl.DataFrame(
+            {
+                "test_time_millisecond": [1000.0],
+                "voltage_volt": [3.7],
+                "current_ampere": [0.1],
+            }
+        )
+        with pytest.warns(UserWarning, match="Legacy BDF column labels detected"):
+            out = BDF_NORMALIZER.normalize(df)
+        assert "Test Time / s" in out.columns
+        assert out["Test Time / s"][0] == 1.0
+
 
 class TestTimezoneHandling:
     """Naive vs tz-aware unix_time_second parsing under the tz parameter."""

--- a/tests/unit/test_table_normalizers.py
+++ b/tests/unit/test_table_normalizers.py
@@ -17,6 +17,7 @@ from bdf.table_normalizers import (
     ResolvedColumn,
     Syn,
     TableNormalizer,
+    _build_bdf_normalizer,
     normalize,
 )
 
@@ -931,16 +932,60 @@ class TestBDFNormalizer:
         assert out.columns == ["Test Time / s", "Voltage / V", "Current / A"]
 
     def test_bdf_normalizer_warns_for_legacy_cols(self):
-        df = pl.DataFrame(
-            {
-                "test_time_millisecond": [1000.0],
-                "voltage_volt": [3.7],
-                "current_ampere": [0.1],
-            }
-        )
+        df = pl.DataFrame({"test_time_millisecond": [1000.0], "voltage_volt": [3.7], "current_ampere": [0.1]})
         with pytest.warns(UserWarning, match="Legacy BDF column labels detected"):
             out = BDF_NORMALIZER.normalize(df)
         assert "Test Time / s" in out.columns
+        assert out["Test Time / s"][0] == 1.0
+
+        df = pl.DataFrame({"Test Time / ms": [1000.0], "Voltage / V": [3.7], "Current / A": [0.1]})
+        with pytest.warns(UserWarning, match="Legacy BDF column labels detected"):
+            out = BDF_NORMALIZER.normalize(df)
+        assert "Test Time / s" in out.columns
+        assert out["Test Time / s"][0] == 1.0
+
+    def test_bdf_normalizer_does_not_warn_for_good_cols(self):
+        df = pl.DataFrame({"test_time_second": [1.0], "voltage_volt": [3.7], "current_ampere": [0.1]})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # Error if any warnings happen
+            out = BDF_NORMALIZER.normalize(df)
+        assert "Test Time / s" in out.columns
+        assert out["Test Time / s"][0] == 1.0
+
+        df = pl.DataFrame({"Test Time / s": [1.0], "Voltage / V": [3.7], "Current / A": [0.1]})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # Error if any warnings happen
+            out = BDF_NORMALIZER.normalize(df)
+        assert "Test Time / s" in out.columns
+        assert out["Test Time / s"][0] == 1.0
+
+    def test_bdf_normalizer_legacy_detection_is_order_independent(self, monkeypatch):
+        """_build_bdf_normalizer must not depend on COLUMN_ONTOLOGY's iteration order.
+
+        The normaliser appends synonyms to a list and iterates through them when matching
+        columns. Legacy detection should work independent of this order.
+        """
+        reversed_quantities = dict(reversed(list(COLUMN_ONTOLOGY._quantities.items())))
+        monkeypatch.setattr(COLUMN_ONTOLOGY, "_quantities", reversed_quantities)
+
+        reversed_normalizer = _build_bdf_normalizer()
+        df = pl.DataFrame({"test_time_millisecond": [1000.0], "voltage_volt": [3.7], "current_ampere": [0.1]})
+        with pytest.warns(UserWarning, match="Legacy BDF column labels detected"):
+            out = reversed_normalizer.normalize(df)
+        assert out["Test Time / s"][0] == 1.0
+        df = pl.DataFrame({"Test Time / ms": [1000.0], "Voltage / V": [3.7], "Current / A": [0.1]})
+        with pytest.warns(UserWarning, match="Legacy BDF column labels detected"):
+            out = reversed_normalizer.normalize(df)
+        assert out["Test Time / s"][0] == 1.0
+
+        df = pl.DataFrame({"test_time_second": [1.0], "voltage_volt": [3.7], "current_ampere": [0.1]})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # Error if any warnings happen
+            out = reversed_normalizer.normalize(df)
+        df = pl.DataFrame({"Test Time / s": [1.0], "Voltage / V": [3.7], "Current / A": [0.1]})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # Error if any warnings happen
+            out = reversed_normalizer.normalize(df)
         assert out["Test Time / s"][0] == 1.0
 
 


### PR DESCRIPTION
Adds `legacy` bool to `Syn`/`ResolvedColumn`

Gets set in `_build_bdf_normalizer`

Warns user when normalizing, e.g. with the `tests\data\bdf\legacy.bdf.parquet`:
```
UserWarning: Legacy BDF column labels detected and normalized to preferred labels: 'test_time_millisecond' -> 'Test Time / s'
```

Adds a small unit test for the bdf normalizer

This is a step towards removing `canonicalize_legacy_labels`, `load` etc. and just using `read` for all file types. We have a similar warning in `load` but not in `read`.