### PR TITLE
Add json, ndjson, ipc/arrow/feather `TableParser`

### DIFF
--- a/src/bdf/plugins.py
+++ b/src/bdf/plugins.py
@@ -33,7 +33,16 @@ from pydantic import BaseModel, ConfigDict, Field
 from .file_utils import is_url, read_head, resolve_source
 from .metadata_parsers import JsonSidecarParser, MetadataParser, MetadataSchema, TxtPreambleParser
 from .table_normalizers import BDF_NORMALIZER, NDA_NORMALIZER, NORMALIZERS, TableNormalizer
-from .table_parsers import DelimTxtParser, ExcelParser, MatParser, NDAParser, ParquetParser
+from .table_parsers import (
+    DelimTxtParser,
+    ExcelParser,
+    IPCParser,
+    JsonParser,
+    MatParser,
+    NDAParser,
+    NdjsonParser,
+    ParquetParser,
+)
 
 try:
     import yaml
@@ -45,7 +54,7 @@ except ImportError as _exc:
     _YAML_IMPORT_ERROR = _exc
 
 TableParserUnion = Annotated[
-    DelimTxtParser | ExcelParser | MatParser | ParquetParser | NDAParser,
+    DelimTxtParser | ExcelParser | IPCParser | JsonParser | MatParser | NDAParser | NdjsonParser | ParquetParser,
     Field(discriminator="kind"),
 ]
 MetadataUnion = Annotated[
@@ -205,7 +214,9 @@ BDF_CSV = Plugin(
 )
 
 BDF_PARQUET = Plugin(table_parser=ParquetParser(normalizer=BDF_NORMALIZER))
-
+BDF_JSON = Plugin(table_parser=JsonParser(normalizer=BDF_NORMALIZER))
+BDF_NDJSON = Plugin(table_parser=NdjsonParser(normalizer=BDF_NORMALIZER))
+BDF_IPC = Plugin(table_parser=IPCParser(normalizer=BDF_NORMALIZER))
 
 PLUGINS: dict[str, Plugin] = PluginDict(
     {
@@ -222,6 +233,9 @@ PLUGINS: dict[str, Plugin] = PluginDict(
         "neware_nda": NEWARE_NDA,
         "bdf_csv": BDF_CSV,
         "bdf_parquet": BDF_PARQUET,
+        "bdf_json": BDF_JSON,
+        "bdf_ndjson": BDF_NDJSON,
+        "bdf_ipc": BDF_IPC,
     }
 )
 

--- a/src/bdf/plugins.py
+++ b/src/bdf/plugins.py
@@ -36,7 +36,7 @@ from .table_normalizers import BDF_NORMALIZER, NDA_NORMALIZER, NORMALIZERS, Tabl
 from .table_parsers import (
     DelimTxtParser,
     ExcelParser,
-    IPCParser,
+    IpcParser,
     JsonParser,
     MatParser,
     NDAParser,
@@ -54,7 +54,7 @@ except ImportError as _exc:
     _YAML_IMPORT_ERROR = _exc
 
 TableParserUnion = Annotated[
-    DelimTxtParser | ExcelParser | IPCParser | JsonParser | MatParser | NDAParser | NdjsonParser | ParquetParser,
+    DelimTxtParser | ExcelParser | IpcParser | JsonParser | MatParser | NDAParser | NdjsonParser | ParquetParser,
     Field(discriminator="kind"),
 ]
 MetadataUnion = Annotated[
@@ -216,7 +216,7 @@ BDF_CSV = Plugin(
 BDF_PARQUET = Plugin(table_parser=ParquetParser(normalizer=BDF_NORMALIZER))
 BDF_JSON = Plugin(table_parser=JsonParser(normalizer=BDF_NORMALIZER))
 BDF_NDJSON = Plugin(table_parser=NdjsonParser(normalizer=BDF_NORMALIZER))
-BDF_IPC = Plugin(table_parser=IPCParser(normalizer=BDF_NORMALIZER))
+BDF_IPC = Plugin(table_parser=IpcParser(normalizer=BDF_NORMALIZER))
 
 PLUGINS: dict[str, Plugin] = PluginDict(
     {

--- a/src/bdf/plugins.py
+++ b/src/bdf/plugins.py
@@ -308,9 +308,12 @@ def detect_from_ext_or_magic_bytes(
     """Return plugins from ``cands`` whose table parser handles the extension of ``path``.
 
     Defaults to :data:`PLUGINS`. The extension is read from the path/URL string alone
-    (no network I/O, no local file access). Falls back to :func:`detect_from_magic_bytes`
-    — which does fetch/read the file — when ``path`` has no extension, or no candidate
-    handles the extension found.
+    (no network I/O, no local file access). Tries at most three suffix forms, longest
+    first: all suffixes joined (``.a.b.c.bdf.parquet``), then the last two (``.bdf.parquet``),
+    then just the last (``.parquet``). A parser whose ``base_exts`` only registers the bare
+    extension still matches filenames with extra dotted segments before it. Falls back
+    to :func:`detect_from_magic_bytes` — which does fetch/read the file — when ``path``
+    has no extension, or no candidate handles any suffix form.
 
     Args:
         path: Local file path or URL to check.
@@ -323,8 +326,13 @@ def detect_from_ext_or_magic_bytes(
         ValueError: If neither the extension nor magic bytes match any candidate.
     """
     path_str = str(path)
-    ext = _ext_from_url(path_str) if is_url(path_str) else "".join(Path(path).suffixes).lower()
-    if ext:
+    if is_url(path_str):
+        exts = [_ext_from_url(path_str)]
+    else:
+        suffixes = Path(path).suffixes
+        exts = ["".join(suffixes), "".join(suffixes[-2:]), "".join(suffixes[-1:])]
+        exts = [e.lower() for e in exts]
+    for ext in dict.fromkeys(e for e in exts if e):  # de-dupe, preserve order
         matched = {id_: p for id_, p in cands.items() if p.table_parser.matches_ext(ext)}
         if matched:
             return matched

--- a/src/bdf/table_parsers.py
+++ b/src/bdf/table_parsers.py
@@ -738,7 +738,7 @@ class NdjsonParser(TableParser):
     is_text: ClassVar[bool] = True
 
     def _read_raw(self, path: str | Path) -> pl.LazyFrame:
-        """Read ndjson file to a LazyFrame. Cannot be truly lazy.
+        """Read ndjson file to a LazyFrame.
 
         Args:
             path: Local file path or URL to ndjson file.

--- a/src/bdf/table_parsers.py
+++ b/src/bdf/table_parsers.py
@@ -761,11 +761,11 @@ class NdjsonParser(TableParser):
 
 
 # ---------------------------------------------------------------------------
-# IPCParser
+# IpcParser
 # ---------------------------------------------------------------------------
 
 
-class IPCParser(TableParser):
+class IpcParser(TableParser):
     """Wraps :func:`polars.scan_ipc` for .ipc/.arrow/.feather files."""
 
     model_config = ConfigDict(frozen=True)

--- a/src/bdf/table_parsers.py
+++ b/src/bdf/table_parsers.py
@@ -702,7 +702,7 @@ class JsonParser(TableParser):
         """
         import json
 
-        with Path(path).open("r") as f:
+        with Path(path).open("r", encoding="utf-8") as f:
             data = json.load(f)
         return pl.LazyFrame(data)
 
@@ -717,7 +717,7 @@ class JsonParser(TableParser):
         """
         import json
 
-        with Path(path).open("r") as f:
+        with Path(path).open("r", encoding="utf-8") as f:
             data = json.load(f)
         return pl.LazyFrame(data).collect_schema().names()
 

--- a/src/bdf/table_parsers.py
+++ b/src/bdf/table_parsers.py
@@ -673,6 +673,133 @@ class ParquetParser(TableParser):
 
 
 # ---------------------------------------------------------------------------
+# JsonParser
+# ---------------------------------------------------------------------------
+
+
+class JsonParser(TableParser):
+    """Wraps json load and :func:`polars.from_dict`
+
+    :func:`polars.read_json` can ONLY read records-oriented json
+    :func:`polars.LazyFrame(dict)` works both records-oriented and list-oriented
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["json"] = "json"
+
+    base_exts: ClassVar[frozenset[str]] = frozenset({".json"})
+    is_text: ClassVar[bool] = True
+
+    def _read_raw(self, path: str | Path) -> pl.LazyFrame:
+        """Read json file to a LazyFrame. Cannot be truly lazy.
+
+        Args:
+            path: Local file path or URL to json file.
+
+        Returns:
+            A polars LazyFrame containing the json data.
+        """
+        import json
+
+        with Path(path).open("r") as f:
+            data = json.load(f)
+        return pl.LazyFrame(data)
+
+    def read_column_headings(self, path: str | Path) -> list[str]:
+        """Extract column names from json file.
+
+        Args:
+            path: Local file path or URL to json file.
+
+        Returns:
+            List of column names.
+        """
+        import json
+
+        with Path(path).open("r") as f:
+            data = json.load(f)
+        return pl.LazyFrame(data).collect_schema().names()
+
+
+# ---------------------------------------------------------------------------
+# NdjsonParser
+# ---------------------------------------------------------------------------
+
+
+class NdjsonParser(TableParser):
+    """Wraps :func:`polars.scan_ndjson` for .ndjson files."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["ndjson"] = "ndjson"
+
+    base_exts: ClassVar[frozenset[str]] = frozenset({".ndjson"})
+    is_text: ClassVar[bool] = True
+
+    def _read_raw(self, path: str | Path) -> pl.LazyFrame:
+        """Read ndjson file to a LazyFrame. Cannot be truly lazy.
+
+        Args:
+            path: Local file path or URL to ndjson file.
+
+        Returns:
+            A polars LazyFrame containing the ndjson data.
+        """
+        return pl.scan_ndjson(path)
+
+    def read_column_headings(self, path: str | Path) -> list[str]:
+        """Extract column names from ndjson file.
+
+        Args:
+            path: Local file path or URL to ndjson file.
+
+        Returns:
+            List of column names.
+        """
+        return pl.scan_ndjson(path).collect_schema().names()
+
+
+# ---------------------------------------------------------------------------
+# IPCParser
+# ---------------------------------------------------------------------------
+
+
+class IPCParser(TableParser):
+    """Wraps :func:`polars.scan_ipc` for .ipc/.arrow/.feather files."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["ipc"] = "ipc"
+
+    base_exts: ClassVar[frozenset[str]] = frozenset({".ipc", ".arrow", ".feather", ".ftr"})
+    magic_bytes: ClassVar[frozenset[bytes]] = frozenset({b"ARROW1"})
+    is_text: ClassVar[bool] = False
+
+    def _read_raw(self, path: str | Path) -> pl.LazyFrame:
+        """Read IPC file to a LazyFrame.
+
+        Args:
+            path: Local file path or URL to IPC file.
+
+        Returns:
+            A polars LazyFrame containing the IPC data.
+        """
+        return pl.scan_ipc(path)
+
+    def read_column_headings(self, path: str | Path) -> list[str]:
+        """Extract column names from IPC file.
+
+        Args:
+            path: Local file path or URL to IPC file.
+
+        Returns:
+            List of column names.
+        """
+        return pl.scan_ipc(path).collect_schema().names()
+
+
+# ---------------------------------------------------------------------------
 # NDAParser
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_read.py
+++ b/tests/unit/test_read.py
@@ -1,0 +1,55 @@
+"""Test reading from various formats."""
+
+from pathlib import Path
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+import bdf
+
+
+def test_read_bdf_files(tmp_path: Path) -> None:
+    """Read bdf from various files."""
+    df1 = pl.DataFrame(
+        {
+            "Test Time / s": [1.0, 2.0, 3.0],
+            "Voltage / V": [4.0, 4.1, 4.2],
+            "Current / A": [0.1, 0.1, 0.1],
+        }
+    )
+
+    for extra_ext in ("", ".bdf", ".a.b.c", ".a.b.c.bdf"):
+        p = tmp_path / f"data{extra_ext}.csv"
+        df1.write_csv(p)
+        df2, _metadata = bdf.read(p, lazy=False)
+        assert_frame_equal(df1, df2)
+
+        p = tmp_path / f"data{extra_ext}.parquet"
+        df1.write_parquet(p)
+        df2, _metadata = bdf.read(p, lazy=False)
+        assert_frame_equal(df1, df2)
+
+        p = tmp_path / f"data{extra_ext}.json"
+        df1.write_json(p)
+        df2, _metadata = bdf.read(p, lazy=False)
+        assert_frame_equal(df1, df2)
+
+        p = tmp_path / f"data{extra_ext}.ndjson"
+        df1.write_ndjson(p)
+        df2, _metadata = bdf.read(p, lazy=False)
+        assert_frame_equal(df1, df2)
+
+        p = tmp_path / f"data{extra_ext}.ipc"
+        df1.write_ipc(p)
+        df2, _metadata = bdf.read(p, lazy=False)
+        assert_frame_equal(df1, df2)
+
+        p = tmp_path / f"data{extra_ext}.arrow"
+        df1.write_ipc(p)
+        df2, _metadata = bdf.read(p, lazy=False)
+        assert_frame_equal(df1, df2)
+
+        p = tmp_path / f"data{extra_ext}.feather"
+        df1.write_ipc(p)
+        df2, _metadata = bdf.read(p, lazy=False)
+        assert_frame_equal(df1, df2)

--- a/tests/unit/test_table_parsers.py
+++ b/tests/unit/test_table_parsers.py
@@ -8,13 +8,25 @@ tests run over the real files under ``tests/data/`` and skip when absent.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import polars as pl
 import pytest
 
+import bdf
 from bdf.table_normalizers import ResolvedColumn, Syn, TableNormalizer
-from bdf.table_parsers import DelimTxtParser, ExcelParser, MatParser, NDAParser, ParquetParser, TableParser
+from bdf.table_parsers import (
+    DelimTxtParser,
+    ExcelParser,
+    IPCParser,
+    JsonParser,
+    MatParser,
+    NDAParser,
+    NdjsonParser,
+    ParquetParser,
+    TableParser,
+)
 
 
 class TestMatchesExt:
@@ -653,6 +665,148 @@ class TestParquetParser:
         assert "Voltage / V" in df.columns
         assert "Current / A" in df.columns
         assert pytest.approx(df["Current / A"][0]) == 0.5
+
+    def test_read_raw_without_extension(self, tmp_path: Path) -> None:
+        """ParquetParser._read_raw works without extension (using magic bytes)."""
+        p = tmp_path / "data"
+        pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}).write_parquet(p)
+        lf, _metadata = bdf.read(p, normalize=False)
+        assert isinstance(lf, pl.LazyFrame)
+        assert lf.collect_schema().names() == ["a", "b"]
+
+
+class TestJsonParser:
+    def test_read_raw(self, tmp_path: Path) -> None:
+        """JsonParser._read_raw returns LazyFrame with correct column names."""
+        p = tmp_path / "data.json"
+        pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}).write_json(p)
+        parser = JsonParser()
+        lf = parser._read_raw(p)
+        assert isinstance(lf, pl.LazyFrame)
+        assert lf.collect_schema().names() == ["a", "b"]
+
+    def test_read_column_headings(self, tmp_path: Path) -> None:
+        """JsonParser.read_column_headings returns column names without data rows."""
+        p = tmp_path / "data.json"
+        pl.DataFrame({"x": [1], "y": [2]}).write_json(p)
+        parser = JsonParser()
+        assert parser.read_column_headings(p) == ["x", "y"]
+
+    def test_read_normalized(self, tmp_path: Path) -> None:
+        """JsonParser applies normalizer to produce BDF columns with correct scaling."""
+        p = tmp_path / "data.json"
+        pl.DataFrame({"voltage_V": [3.7], "current_mA": [500.0]}).write_json(p)
+        norm = TableNormalizer(
+            voltage_volt=(Syn(hdr="voltage_{unit}"),),
+            current_ampere=(Syn(hdr="current_{unit}"),),
+        )
+        parser = JsonParser(normalizer=norm)
+        df = parser.read(p, validate=False).collect()
+        assert "Voltage / V" in df.columns
+        assert "Current / A" in df.columns
+        assert pytest.approx(df["Current / A"][0]) == 0.5
+
+    def test_read_raw_column_oriented(self, tmp_path: Path) -> None:
+        """JsonParser._read_raw works for both record-oriented and list-oriented json."""
+        parser = JsonParser()
+
+        p_record = tmp_path / "data_record.json"
+        data_record = [
+            {"a": 1.0, "b": 3.0},
+            {"a": 2.0, "b": 4.0},
+        ]
+        with p_record.open("w") as f:
+            json.dump(data_record, f)
+        lf = parser._read_raw(p_record)
+        assert isinstance(lf, pl.LazyFrame)
+        assert lf.collect_schema().names() == ["a", "b"]
+        df = lf.collect()
+        assert len(df) == 2
+
+        p_list = tmp_path / "data_list.json"
+        data_list = {
+            "a": [1.0, 2.0],
+            "b": [3.0, 4.0],
+        }
+        with p_list.open("w") as f:
+            json.dump(data_list, f)
+        lf = parser._read_raw(p_list)
+        assert isinstance(lf, pl.LazyFrame)
+        assert lf.collect_schema().names() == ["a", "b"]
+        df = lf.collect()
+        assert len(df) == 2
+
+
+class TestNdjsonParser:
+    def test_read_raw(self, tmp_path: Path) -> None:
+        """NdjsonParser._read_raw returns LazyFrame with correct column names."""
+        p = tmp_path / "data.ndjson"
+        pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}).write_ndjson(p)
+        parser = NdjsonParser()
+        lf = parser._read_raw(p)
+        assert isinstance(lf, pl.LazyFrame)
+        assert lf.collect_schema().names() == ["a", "b"]
+
+    def test_read_column_headings(self, tmp_path: Path) -> None:
+        """NdjsonParser.read_column_headings returns column names without data rows."""
+        p = tmp_path / "data.ndjson"
+        pl.DataFrame({"x": [1], "y": [2]}).write_ndjson(p)
+        parser = NdjsonParser()
+        assert parser.read_column_headings(p) == ["x", "y"]
+
+    def test_read_normalized(self, tmp_path: Path) -> None:
+        """NdjsonParser applies normalizer to produce BDF columns with correct scaling."""
+        p = tmp_path / "data.ndjson"
+        pl.DataFrame({"voltage_V": [3.7], "current_mA": [500.0]}).write_ndjson(p)
+        norm = TableNormalizer(
+            voltage_volt=(Syn(hdr="voltage_{unit}"),),
+            current_ampere=(Syn(hdr="current_{unit}"),),
+        )
+        parser = NdjsonParser(normalizer=norm)
+        df = parser.read(p, validate=False).collect()
+        assert "Voltage / V" in df.columns
+        assert "Current / A" in df.columns
+        assert pytest.approx(df["Current / A"][0]) == 0.5
+
+
+class TestIPCParser:
+    def test_read_raw(self, tmp_path: Path) -> None:
+        """IPCParser._read_raw returns LazyFrame with correct column names."""
+        p = tmp_path / "data.ipc"
+        pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}).write_ipc(p)
+        parser = IPCParser()
+        lf = parser._read_raw(p)
+        assert isinstance(lf, pl.LazyFrame)
+        assert lf.collect_schema().names() == ["a", "b"]
+
+    def test_read_column_headings(self, tmp_path: Path) -> None:
+        """IPCParser.read_column_headings returns column names without data rows."""
+        p = tmp_path / "data.ipc"
+        pl.DataFrame({"x": [1], "y": [2]}).write_ipc(p)
+        parser = IPCParser()
+        assert parser.read_column_headings(p) == ["x", "y"]
+
+    def test_read_normalized(self, tmp_path: Path) -> None:
+        """IPCParser applies normalizer to produce BDF columns with correct scaling."""
+        p = tmp_path / "data.ipc"
+        pl.DataFrame({"voltage_V": [3.7], "current_mA": [500.0]}).write_ipc(p)
+        norm = TableNormalizer(
+            voltage_volt=(Syn(hdr="voltage_{unit}"),),
+            current_ampere=(Syn(hdr="current_{unit}"),),
+        )
+        parser = IPCParser(normalizer=norm)
+        df = parser.read(p, validate=False).collect()
+        assert "Voltage / V" in df.columns
+        assert "Current / A" in df.columns
+        assert pytest.approx(df["Current / A"][0]) == 0.5
+
+    def test_read_raw_without_extension(self, tmp_path: Path) -> None:
+        """IPCParser._read_raw works without extension (using magic bytes)."""
+        p = tmp_path / "data"
+        pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}).write_ipc(p)
+        lf, _metadata = bdf.read(p, normalize=False)
+        assert isinstance(lf, pl.LazyFrame)
+        assert lf.collect_schema().names() == ["a", "b"]
 
 
 class TestNDAParser:

--- a/tests/unit/test_table_parsers.py
+++ b/tests/unit/test_table_parsers.py
@@ -736,6 +736,22 @@ class TestJsonParser:
         df = lf.collect()
         assert len(df) == 2
 
+    def test_special_characters(self, tmp_path: Path) -> None:
+        parser = JsonParser()
+
+        p_record = tmp_path / "data_record.json"
+        data_record = [
+            {"q [µA·h]": 1.0, "R [Ω]": 2.0, "sweep [mV s⁻¹]": 3.0, "T1 [°C]": 4.0, "T2 [℃]": 5.0},
+            {"q [µA·h]": 1.1, "R [Ω]": 2.1, "sweep [mV s⁻¹]": 3.1, "T1 [°C]": 4.1, "T2 [℃]": 5.1},
+        ]
+        with p_record.open("w", encoding="utf-8") as f:
+            json.dump(data_record, f, ensure_ascii=False)
+        lf = parser._read_raw(p_record)
+        assert isinstance(lf, pl.LazyFrame)
+        df = lf.collect()
+        assert len(df) == 2
+        assert all(col in df.columns for col in ["q [µA·h]", "R [Ω]", "sweep [mV s⁻¹]", "T1 [°C]", "T2 [℃]"])
+
 
 class TestNdjsonParser:
     def test_read_raw(self, tmp_path: Path) -> None:

--- a/tests/unit/test_table_parsers.py
+++ b/tests/unit/test_table_parsers.py
@@ -19,7 +19,7 @@ from bdf.table_normalizers import ResolvedColumn, Syn, TableNormalizer
 from bdf.table_parsers import (
     DelimTxtParser,
     ExcelParser,
-    IPCParser,
+    IpcParser,
     JsonParser,
     MatParser,
     NDAParser,
@@ -769,39 +769,39 @@ class TestNdjsonParser:
         assert pytest.approx(df["Current / A"][0]) == 0.5
 
 
-class TestIPCParser:
+class TestIpcParser:
     def test_read_raw(self, tmp_path: Path) -> None:
-        """IPCParser._read_raw returns LazyFrame with correct column names."""
+        """IpcParser._read_raw returns LazyFrame with correct column names."""
         p = tmp_path / "data.ipc"
         pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}).write_ipc(p)
-        parser = IPCParser()
+        parser = IpcParser()
         lf = parser._read_raw(p)
         assert isinstance(lf, pl.LazyFrame)
         assert lf.collect_schema().names() == ["a", "b"]
 
     def test_read_column_headings(self, tmp_path: Path) -> None:
-        """IPCParser.read_column_headings returns column names without data rows."""
+        """IpcParser.read_column_headings returns column names without data rows."""
         p = tmp_path / "data.ipc"
         pl.DataFrame({"x": [1], "y": [2]}).write_ipc(p)
-        parser = IPCParser()
+        parser = IpcParser()
         assert parser.read_column_headings(p) == ["x", "y"]
 
     def test_read_normalized(self, tmp_path: Path) -> None:
-        """IPCParser applies normalizer to produce BDF columns with correct scaling."""
+        """IpcParser applies normalizer to produce BDF columns with correct scaling."""
         p = tmp_path / "data.ipc"
         pl.DataFrame({"voltage_V": [3.7], "current_mA": [500.0]}).write_ipc(p)
         norm = TableNormalizer(
             voltage_volt=(Syn(hdr="voltage_{unit}"),),
             current_ampere=(Syn(hdr="current_{unit}"),),
         )
-        parser = IPCParser(normalizer=norm)
+        parser = IpcParser(normalizer=norm)
         df = parser.read(p, validate=False).collect()
         assert "Voltage / V" in df.columns
         assert "Current / A" in df.columns
         assert pytest.approx(df["Current / A"][0]) == 0.5
 
     def test_read_raw_without_extension(self, tmp_path: Path) -> None:
-        """IPCParser._read_raw works without extension (using magic bytes)."""
+        """IpcParser._read_raw works without extension (using magic bytes)."""
         p = tmp_path / "data"
         pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}).write_ipc(p)
         lf, _metadata = bdf.read(p, normalize=False)

--- a/tests/unit/test_table_parsers.py
+++ b/tests/unit/test_table_parsers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 import pytest
@@ -736,9 +737,19 @@ class TestJsonParser:
         df = lf.collect()
         assert len(df) == 2
 
-    def test_special_characters(self, tmp_path: Path) -> None:
-        parser = JsonParser()
+    def test_special_characters(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Spy on Path.open to check encodings used
+        original_open = Path.open
+        calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
 
+        def spy_open(self: Path, *args: Any, **kwargs: Any) -> object:
+            calls.append((args, kwargs))
+            return original_open(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", spy_open)
+
+        # Open file with special characters and assert they do not become garbled
+        parser = JsonParser()
         p_record = tmp_path / "data_record.json"
         data_record = [
             {"q [µA·h]": 1.0, "R [Ω]": 2.0, "sweep [mV s⁻¹]": 3.0, "T1 [°C]": 4.0, "T2 [℃]": 5.0},
@@ -751,6 +762,18 @@ class TestJsonParser:
         df = lf.collect()
         assert len(df) == 2
         assert all(col in df.columns for col in ["q [µA·h]", "R [Ω]", "sweep [mV s⁻¹]", "T1 [°C]", "T2 [℃]"])
+        columns = lf = parser.read_column_headings(p_record)
+        assert columns == ["q [µA·h]", "R [Ω]", "sweep [mV s⁻¹]", "T1 [°C]", "T2 [℃]"]
+
+        # Assert that all Path.open was explicitly given utf-8 encoding
+        # Otherwise Linux CI runners pass this test whether or not encoding was given
+        assert calls, "Path.open was never called"
+        for args, kwargs in calls:
+            mode = args[0] if args else kwargs.get("mode", "r")
+            if "b" in mode:
+                continue
+            encoding = args[1] if len(args) > 1 else kwargs.get("encoding")
+            assert encoding == "utf-8", f"opened in text mode without encoding='utf-8': args={args} kwargs={kwargs}"
 
 
 class TestNdjsonParser:


### PR DESCRIPTION
In #76 I add the option to save to json/ndjson/ipc/arrow/feather, but we can't read it back.

This PR adds these as BDF table parsers, in the same way as the existing parquet parser.

Splitting into separate PR because this part is non-destructive and an easy merge.

`polars.read_json` only handles record-oriented json (which would make enormous files for us). I used `json.load` then put it in `LazyFrame(data)` which works for both record- and list- oriented json.

Also caught a subtle bug, table parsers were trying to match the last suffix (e.g. ".parquet") to all suffixes combined (e.g. ".bdf.parquet"). This means it would also fail if there are other dots in the filename. It was always silently falling back on the magic bytes for ".bdf.parquet" files. Now it checks all suffixes, last two suffixes, last suffix.