### PR TITLE
refactor(repair): port to polars-native internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [Unreleased]
 ### Added
+- repair.py ported to polars-native internals: fix_time and clean now accept polars (eager or lazy) or pandas frames and return the same kind, with identical numeric results across input types (pinned by the characterization suite). mypy re-enabled on the module; the CLI clean command no longer round-trips through pandas.
 - Arbin normalizers (csv, xlsx) map Charge/Discharge Capacity and Energy to the schedule_* terms from ontology 1.3.0, reflecting the operator-defined reset behavior Arbin confirmed; the columns previously landed on the never-resetting test-scoped terms.
 - CI pipeline with lint/type/tests/docs and build/twine checks.
 - Sphinx docs with pydata theme and converted notebook examples.

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,9 +10,6 @@ mypy_path = src
 packages = bdf
 plugins =
 
-[mypy-bdf.repair]
-ignore_errors = True
-
 [mypy-bdf.metadata]
 ignore_errors = True
 

--- a/src/bdf/cli.py
+++ b/src/bdf/cli.py
@@ -195,12 +195,9 @@ def clean(
     Accepts either BDF CSV/Parquet or a raw vendor file.
     """
     # Load BDF
-    import polars as pl
 
-    df_pl, _ = read(path, plugin=as_)
-    df = df_pl.to_pandas()
+    df, _ = read(path, plugin=as_)
     df, rep = clean_bdf(df, time_fix=time_fix, outlier=outlier, z_thresh=z, columns=col)
-    df_pl = pl.from_pandas(df)
     save(df, out)
     typer.echo(str(rep))
     typer.echo(f"Saved: {out}")

--- a/src/bdf/repair.py
+++ b/src/bdf/repair.py
@@ -1,11 +1,21 @@
 # src/bdf/repair.py
+"""Time repair and outlier cleaning for BDF tables.
+
+Polars-native internals; accepts polars (eager or lazy) or pandas frames and
+returns the same kind it was given. All numeric heavy lifting runs on numpy
+arrays, so results are identical across input types.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy as np
-import pandas as pd
+import polars as pl
+
+if TYPE_CHECKING:
+    import pandas as pd  # noqa: F401
 
 # Optional SciPy robust stats (preferred), with graceful fallback
 try:
@@ -14,6 +24,7 @@ except Exception:
     sps = None  # type: ignore
 
 from . import spec
+from ._df_compat import _classify_df, _to_polars_lazy
 
 TIME_COL = spec.COLUMN_ONTOLOGY.test_time_second.formatted_label
 DEFAULT_OUTLIER_COLS = (
@@ -53,6 +64,31 @@ class CleanReport:
 
 
 # -----------------------------
+# Frame boundary helpers
+# -----------------------------
+def _to_polars_eager(df) -> tuple[pl.DataFrame, str]:
+    """Convert any supported frame to an eager pl.DataFrame, remembering its kind."""
+    kind = _classify_df(df)
+    return _to_polars_lazy(df).collect(), kind
+
+
+def _from_polars_eager(df: pl.DataFrame, kind: str):
+    """Convert an eager pl.DataFrame back to the caller's frame kind."""
+    if kind == "pandas":
+        return df.to_pandas()
+    if kind == "polars_lazy":
+        return df.lazy()
+    return df
+
+
+def _numeric(df: pl.DataFrame, col: str) -> np.ndarray:
+    """Column as float64 numpy array; non-numeric values become NaN."""
+    s = df[col]
+    s = s.cast(pl.Float64, strict=False) if s.dtype == pl.Utf8 else s.cast(pl.Float64)
+    return s.fill_null(float("nan")).to_numpy()
+
+
+# -----------------------------
 # Time helpers
 # -----------------------------
 def _compute_eps_from_diffs(diffs: np.ndarray) -> float:
@@ -70,7 +106,7 @@ def _median_positive_dt(ts: np.ndarray) -> float:
     return float(np.nanmedian(pos))
 
 
-def _fix_time_between_neighbors(t: pd.Series, eps: float | str = "auto") -> Tuple[pd.Series, int]:
+def _fix_time_between_neighbors(ts: np.ndarray, eps: float | str = "auto") -> Tuple[np.ndarray, int]:
     """
     Make time monotonic by placing each non-monotonic block strictly between its
     two monotonic neighbors. Keeps all rows and preserves ordering.
@@ -79,10 +115,10 @@ def _fix_time_between_neighbors(t: pd.Series, eps: float | str = "auto") -> Tupl
     first r where t[r] >= t[i-1]+eps, linearly interpolate times for i..r-1
     between t[i-1] and t[r]. If no r exists, use median_dt to synthesize a right neighbor.
     """
-    ts = pd.to_numeric(t, errors="coerce").to_numpy(dtype="float64")
+    ts = ts.astype("float64")
     n = ts.size
     if n <= 1:
-        return pd.Series(ts, index=t.index), 0
+        return ts, 0
 
     diffs = np.diff(ts, prepend=ts[0])
     eps_val = _compute_eps_from_diffs(diffs) if eps == "auto" else float(eps)
@@ -122,29 +158,44 @@ def _fix_time_between_neighbors(t: pd.Series, eps: float | str = "auto") -> Tupl
         resets += 1
         i = j
 
-    return pd.Series(tc, index=t.index), resets
+    return tc, resets
 
 
-def _fix_time_sort(df: pd.DataFrame) -> pd.DataFrame:
+def _fix_time_sort(df: pl.DataFrame, time_col: str = TIME_COL) -> pl.DataFrame:
     """Stable sort by time and drop exact duplicate timestamps (keep first)."""
-    d = df.sort_values(TIME_COL, kind="mergesort").copy()
-    d = d.loc[~d[TIME_COL].duplicated(keep="first")].reset_index(drop=True)
-    return d
+    return df.sort(time_col, maintain_order=True).unique(subset=[time_col], keep="first", maintain_order=True)
 
 
 # -----------------------------
 # Outlier helpers (SciPy-aware)
 # -----------------------------
-def _window_len_from_seconds(time_s: pd.Series, seconds: float, fallback: int = 41) -> int:
-    t = pd.to_numeric(time_s, errors="coerce")
-    if t.notna().sum() > 1:
-        dt = np.median(np.diff(t.dropna().to_numpy()))
+def _window_len_from_seconds(time_s: np.ndarray, seconds: float, fallback: int = 41) -> int:
+    t = time_s[np.isfinite(time_s)]
+    if t.size > 1:
+        dt = np.median(np.diff(t))
         if np.isfinite(dt) and dt > 0:
             w = int(round(seconds / dt))
             if w % 2 == 0:
                 w += 1  # prefer odd window
             return max(5, w)
     return fallback
+
+
+def _rolling(series: np.ndarray, window: int, min_periods: int, stat: str, q: float | None = None) -> np.ndarray:
+    """Centered rolling statistic over a float array, NaN-aware like pandas.
+
+    NaNs are treated as missing: they don't contribute to the statistic and
+    don't count toward ``min_periods``.
+    """
+    s = pl.Series(series).fill_nan(None)
+    if stat == "median":
+        out = s.rolling_median(window_size=window, min_samples=min_periods, center=True)
+    else:
+        assert stat == "quantile" and q is not None
+        out = s.rolling_quantile(
+            quantile=q, interpolation="linear", window_size=window, min_samples=min_periods, center=True
+        )
+    return out.fill_null(float("nan")).to_numpy()
 
 
 def _global_mad_z(x: np.ndarray) -> tuple[np.ndarray, float, float]:
@@ -176,54 +227,55 @@ def _global_huber_z(x: np.ndarray, c: float = 1.345) -> tuple[np.ndarray, float,
     return (x - loc) / scale, loc, scale
 
 
-def _local_robust_z(s: pd.Series, *, time_s: pd.Series, seconds: float, z: float) -> pd.Series:
+def _local_robust_z(x: np.ndarray, *, time_s: np.ndarray, seconds: float, z: float) -> np.ndarray:
     """
     Local robust z using rolling IQR (σ ≈ IQR/1.349).
     Flags |z_local| > z within the window.
     """
     w = _window_len_from_seconds(time_s, seconds)
-    x = pd.to_numeric(s, errors="coerce")
-    med = x.rolling(w, center=True, min_periods=max(3, w // 3)).median()
-    q1 = x.rolling(w, center=True, min_periods=max(3, w // 3)).quantile(0.25)
-    q3 = x.rolling(w, center=True, min_periods=max(3, w // 3)).quantile(0.75)
+    mp = max(3, w // 3)
+    med = _rolling(x, w, mp, "median")
+    q1 = _rolling(x, w, mp, "quantile", 0.25)
+    q3 = _rolling(x, w, mp, "quantile", 0.75)
     sigma = (q3 - q1) / 1.349
-    rz = (x - med) / sigma.replace(0, np.nan)
-    return (rz.abs() > z).fillna(False)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        rz = (x - med) / np.where(sigma == 0, np.nan, sigma)
+    return np.nan_to_num(np.abs(rz), nan=0.0) > z
 
 
-def _hampel_mask(s: pd.Series, *, time_s: pd.Series, seconds: float, k: float = 6.0) -> pd.Series:
+def _hampel_mask(x: np.ndarray, *, time_s: np.ndarray, seconds: float, k: float = 6.0) -> np.ndarray:
     """
     Hampel filter: rolling median ± k * MADN.
     Flags samples deviating more than k scaled MAD from rolling median.
     """
     w = _window_len_from_seconds(time_s, seconds)
-    x = pd.to_numeric(s, errors="coerce")
-    med = x.rolling(w, center=True, min_periods=max(3, w // 3)).median()
-    abs_dev = (x - med).abs()
-    mad = abs_dev.rolling(w, center=True, min_periods=max(3, w // 3)).median()
+    mp = max(3, w // 3)
+    med = _rolling(x, w, mp, "median")
+    abs_dev = np.abs(x - med)
+    mad = _rolling(abs_dev, w, mp, "median")
     madn = 1.4826 * mad
-    return ((x - med).abs() / madn.replace(0, np.nan) > k).fillna(False)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        score = np.abs(x - med) / np.where(madn == 0, np.nan, madn)
+    return np.nan_to_num(score, nan=0.0) > k
 
 
-def _slope_mask(s: pd.Series, *, time_s: pd.Series, z: float = 8.0) -> pd.Series:
+def _slope_mask(x: np.ndarray, *, time_s: np.ndarray, z: float = 8.0) -> np.ndarray:
     """
     Slope gate: robust z on derivative ds/dt using global MAD.
     Catches single-sample spikes that might pass level-based gates.
     """
-    x = pd.to_numeric(s, errors="coerce").to_numpy(dtype="float64")
-    t = pd.to_numeric(time_s, errors="coerce").to_numpy(dtype="float64")
     dx = np.diff(x, prepend=np.nan)
-    dt = np.diff(t, prepend=np.nan)
+    dt = np.diff(time_s, prepend=np.nan)
     with np.errstate(divide="ignore", invalid="ignore"):
         deriv = dx / dt
     zder, _, madn = _global_mad_z(deriv)
     m = (np.abs(zder) > z) if madn > 0 else np.zeros_like(deriv, dtype=bool)
     m[~np.isfinite(deriv)] = False
-    return pd.Series(m, index=s.index)
+    return m
 
 
 def _robust_outlier_mask(
-    s: pd.Series,
+    x: np.ndarray,
     *,
     z_mad: float = 8.0,
     z_huber: float = 6.0,
@@ -235,8 +287,8 @@ def _robust_outlier_mask(
     slope_z: float = 8.0,
     method: str = "hybrid",  # 'mad' | 'huber' | 'hybrid'
     min_n: int = 30,
-    time_s: pd.Series | None = None,
-) -> pd.Series:
+    time_s: np.ndarray | None = None,
+) -> np.ndarray:
     """
     Robust outlier mask using (global) MAD & optional Huber, plus neighborhood gates:
       - Local rolling IQR z
@@ -244,10 +296,9 @@ def _robust_outlier_mask(
       - Slope z on derivative
     Combine as: (GLOBAL AND (LOCAL OR HAMPEL)) OR SLOPE.
     """
-    x = pd.to_numeric(s, errors="coerce").to_numpy(dtype="float64", na_value=np.nan)
     valid = np.isfinite(x)
     if valid.sum() < min_n:
-        return pd.Series(False, index=s.index)
+        return np.zeros_like(x, dtype=bool)
 
     xv = x.copy()
     xv[~valid] = np.nan
@@ -267,8 +318,8 @@ def _robust_outlier_mask(
     # neighborhood gates
     m_neigh = None
     if time_s is not None:
-        m_local = _local_robust_z(s, time_s=time_s, seconds=local_seconds, z=local_z) if local_seconds else None
-        m_hampel = _hampel_mask(s, time_s=time_s, seconds=hampel_seconds, k=hampel_k) if hampel_seconds else None
+        m_local = _local_robust_z(xv, time_s=time_s, seconds=local_seconds, z=local_z) if local_seconds else None
+        m_hampel = _hampel_mask(xv, time_s=time_s, seconds=hampel_seconds, k=hampel_k) if hampel_seconds else None
         if m_local is not None and m_hampel is not None:
             m_neigh = m_local | m_hampel
         elif m_local is not None:
@@ -278,35 +329,37 @@ def _robust_outlier_mask(
 
     m = m_global if m_neigh is None else (m_global & m_neigh)
     if slope_gate and time_s is not None:
-        m = m | _slope_mask(s, time_s=time_s, z=slope_z).values
-
-    out = np.zeros_like(x, dtype=bool)
-    out[:] = m
-    return pd.Series(out, index=s.index)
+        m = m | _slope_mask(xv, time_s=time_s, z=slope_z)
+    return m
 
 
-def _interp_inplace(y: pd.Series, x: Optional[pd.Series]) -> pd.Series:
-    if x is not None:
-        yi = pd.to_numeric(y, errors="coerce").astype("float64")
-        xi = pd.to_numeric(x, errors="coerce")
-        return yi.interpolate(method="values", x=xi, limit_direction="both")
-    return y.interpolate(limit_direction="both")
+def _interp_over_time(y: np.ndarray, mask: np.ndarray, t: np.ndarray) -> np.ndarray:
+    """Replace masked values with linear interpolation over time, extrapolating flat at the edges."""
+    out = y.copy()
+    good = np.isfinite(y) & ~mask & np.isfinite(t)
+    if good.sum() == 0:
+        return out
+    bad = mask | ~np.isfinite(y)
+    out[bad] = np.interp(t[bad], t[good], y[good])
+    return out
 
 
 # -----------------------------
 # Public API -  simple time repair
 # -----------------------------
 def fix_time(
-    df: pd.DataFrame,
+    df,
     *,
     method: str = "auto",  # 'auto'|'segment'|'sort'|'drop'|'recompute'
     time_col: str = TIME_COL,
     date_col: str = "Date Time ISO",
     eps: float | str = "auto",
     inplace: bool = False,
-) -> pd.DataFrame:
+):
     """
     Repair non-monotonic test time.
+
+    Accepts polars (eager or lazy) or pandas frames; returns the same kind.
 
     Methods:
       - 'auto': if Date Time ISO exists & usable, recompute from timestamps; else 'segment'.
@@ -314,40 +367,53 @@ def fix_time(
       - 'sort': stable sort by time ascending; drop exact duplicate timestamps.
       - 'drop': drop rows where time decreases by more than 'eps'.
       - 'recompute': force recompute from Date Time ISO; raises if no valid timestamps.
-    """
-    g = df if inplace else df.copy()
-    if time_col not in g.columns:
-        return g
 
+    ``inplace=True`` mutates the original frame for pandas input only; polars
+    frames are immutable, so the flag has no effect for them.
+    """
+    g, kind = _to_polars_eager(df)
+    if time_col not in g.columns:
+        result = g
+    else:
+        result = _fix_time_polars(g, method=method, time_col=time_col, date_col=date_col, eps=eps)
+
+    if kind == "pandas" and inplace:
+        out = result.to_pandas()
+        df.drop(df.index, inplace=True)
+        for c in out.columns:
+            df[c] = out[c].to_numpy()
+        return df
+    return _from_polars_eager(result, kind)
+
+
+def _fix_time_polars(g: pl.DataFrame, *, method: str, time_col: str, date_col: str, eps: float | str) -> pl.DataFrame:
     if method in ("auto", "recompute"):
         if date_col in g.columns:
-            t = pd.to_datetime(g[date_col], errors="coerce")
-            if t.notna().any():
-                t0 = t[t.notna()].iloc[0]
-                g[time_col] = (t - t0).dt.total_seconds()
-                return g
+            t = g[date_col].cast(pl.Utf8, strict=False).str.to_datetime(strict=False, time_unit="us")
+            if t.null_count() < len(t):
+                t0 = t.drop_nulls()[0]
+                elapsed = (t - t0).dt.total_microseconds() / 1e6
+                return g.with_columns(elapsed.alias(time_col))
         if method == "recompute":
             raise ValueError(f"Cannot recompute from '{date_col}': no valid timestamps.")
 
     if method in ("auto", "segment"):
-        g[time_col], _ = _fix_time_between_neighbors(g[time_col], eps=eps)
-        return g
+        fixed, _ = _fix_time_between_neighbors(_numeric(g, time_col), eps=eps)
+        return g.with_columns(pl.Series(time_col, fixed))
 
     if method == "sort":
-        g.sort_values(by=[time_col], kind="mergesort", inplace=True)
-        g.drop_duplicates(subset=[time_col], keep="first", inplace=True)
-        g.reset_index(drop=True, inplace=True)
-        return g
+        return _fix_time_sort(g, time_col)
 
     if method == "drop":
-        s = pd.to_numeric(g[time_col], errors="coerce")
-        d = s.diff().fillna(0.0)
-        if eps == "auto":
-            eps = _compute_eps_from_diffs(d.to_numpy())
-        keep = d >= -float(eps)
-        keep.iloc[0] = True
-        g = g.loc[keep].reset_index(drop=True)
-        return g
+        s = _numeric(g, time_col)
+        d = np.diff(s, prepend=s[0] if s.size else 0.0)
+        if s.size:
+            d[0] = 0.0
+        eps_val = _compute_eps_from_diffs(d) if eps == "auto" else float(eps)
+        keep = d >= -eps_val
+        if keep.size:
+            keep[0] = True
+        return g.filter(pl.Series(keep))
 
     raise ValueError(f"Unknown method: {method!r}")
 
@@ -356,7 +422,7 @@ def fix_time(
 # Public API -  full cleaner
 # -----------------------------
 def clean(
-    df: pd.DataFrame,
+    df,
     *,
     time_fix: str = "segment",  # 'segment' | 'sort' | 'drop' | 'none'
     outlier: str = "none",  # 'none' | 'drop' | 'clip' | 'interp'
@@ -372,9 +438,12 @@ def clean(
     hampel_k: float = 6.0,
     slope_gate: bool = True,
     slope_z: float = 8.0,
-) -> Tuple[pd.DataFrame, CleanReport]:
+) -> Tuple["pd.DataFrame | pl.DataFrame | pl.LazyFrame", CleanReport]:
     """
-    Clean a BDF-normalized DataFrame.
+    Clean a BDF-normalized table.
+
+    Accepts polars (eager or lazy) or pandas frames; the returned table matches
+    the input kind.
 
     - time_fix:
         'segment'  -> place non-monotonic blocks between neighbors (keeps rows; default)
@@ -394,33 +463,34 @@ def clean(
         Neighborhood & derivative gates to catch single-sample spikes and suppress
         false positives on slow drifts. Combined as: (GLOBAL AND (LOCAL OR HAMPEL)) OR SLOPE.
     """
-    if TIME_COL not in df.columns:
+    d, kind = _to_polars_eager(df)
+    if TIME_COL not in d.columns:
         raise ValueError(f"Missing '{TIME_COL}'. Did you normalize to BDF?")
 
     notes: List[str] = []
-    d = df.copy()
     n_in = len(d)
     cols = [c for c in (columns or DEFAULT_OUTLIER_COLS) if c in d.columns]
 
     # ---- Fix time ----
-    t_numeric = pd.to_numeric(d[TIME_COL], errors="coerce")
-    diffs = np.diff(t_numeric.to_numpy(dtype="float64"), prepend=t_numeric.iloc[0])
+    t_numeric = _numeric(d, TIME_COL)
+    diffs = np.diff(t_numeric, prepend=t_numeric[0] if n_in else 0.0)
     eps_val = _compute_eps_from_diffs(diffs) if time_eps == "auto" else float(time_eps)
     n_resets_detected = int((diffs < -eps_val).sum())
 
     if time_fix == "segment":
-        d[TIME_COL], n_resets_detected = _fix_time_between_neighbors(d[TIME_COL], eps=time_eps)
+        fixed, n_resets_detected = _fix_time_between_neighbors(t_numeric, eps=time_eps)
+        d = d.with_columns(pl.Series(TIME_COL, fixed))
         time_method_used = "segment"
     elif time_fix == "sort":
         d = _fix_time_sort(d)
         time_method_used = "sort"
         n_resets_detected = 0
     elif time_fix == "drop":
-        keep = np.concatenate(([True], diffs[1:] >= -eps_val))
+        keep = np.concatenate(([True], diffs[1:] >= -eps_val)) if n_in else np.array([], dtype=bool)
         dropped = int((~keep).sum())
         if dropped:
             notes.append(f"Dropped {dropped} rows due to time decreases.")
-        d = d.loc[keep].reset_index(drop=True)
+        d = d.filter(pl.Series(keep))
         time_method_used = "drop"
     elif time_fix == "none":
         time_method_used = "none"
@@ -428,17 +498,19 @@ def clean(
         raise ValueError("time_fix must be one of: 'segment','sort','drop','none'")
 
     # Rebase to start at zero if positive
-    tmin = pd.to_numeric(d[TIME_COL], errors="coerce").min()
+    t_now = _numeric(d, TIME_COL)
+    tmin = np.nanmin(t_now) if t_now.size else float("nan")
     if np.isfinite(tmin) and tmin > 0:
-        d[TIME_COL] = pd.to_numeric(d[TIME_COL], errors="coerce") - float(tmin)
+        d = d.with_columns(pl.Series(TIME_COL, t_now - float(tmin)))
 
     # ---- Outliers ----
     per_col: Dict[str, int] = {}
     if outlier != "none" and cols:
-        masks: Dict[str, pd.Series] = {}
+        t_arr = _numeric(d, TIME_COL)
+        masks: Dict[str, np.ndarray] = {}
         for c in cols:
             masks[c] = _robust_outlier_mask(
-                d[c],
+                _numeric(d, c),
                 z_mad=z_thresh,
                 z_huber=z_huber,
                 local_seconds=local_seconds,
@@ -449,23 +521,21 @@ def clean(
                 slope_z=slope_z,
                 method=outlier_detect,
                 min_n=30,
-                time_s=d[TIME_COL],
+                time_s=t_arr,
             )
             per_col[c] = int(masks[c].sum())
 
         if outlier == "drop":
-            any_bad = (
-                np.logical_or.reduce([m.values for m in masks.values()]) if masks else np.zeros(len(d), dtype=bool)
-            )
-            d = d.loc[~any_bad].reset_index(drop=True)
+            any_bad = np.logical_or.reduce(list(masks.values())) if masks else np.zeros(len(d), dtype=bool)
+            d = d.filter(pl.Series(~any_bad))
             notes.append(f"Dropped {int(any_bad.sum())} rows due to outliers in {', '.join(cols)}.")
         elif outlier == "clip":
             # robust bounds via MAD (SciPy if available), fallback to IQR
-            for c, _m in masks.items():
-                s = pd.to_numeric(d[c], errors="coerce")
+            for c in masks:
+                s = _numeric(d, c)
                 med = float(np.nanmedian(s))
                 if sps is not None:
-                    madn = float(sps.median_abs_deviation(s.to_numpy(), nan_policy="omit", scale="normal"))
+                    madn = float(sps.median_abs_deviation(s, nan_policy="omit", scale="normal"))
                 else:
                     mad = float(np.nanmedian(np.abs(s - med)))
                     madn = 1.4826 * mad
@@ -479,14 +549,13 @@ def clean(
                         continue
                     sigma = iqr / 1.349
                     lo, hi = med - z_thresh * sigma, med + z_thresh * sigma
-                d[c] = s.clip(lo, hi)
+                d = d.with_columns(pl.Series(c, np.clip(s, lo, hi)))
             notes.append("Clipped outliers to robust bounds (MAD/IQR).")
         elif outlier == "interp":
-            tx = pd.to_numeric(d[TIME_COL], errors="coerce")
+            tx = _numeric(d, TIME_COL)
             for c, m in masks.items():
-                s = pd.to_numeric(d[c], errors="coerce")
-                s = s.mask(m, np.nan)
-                d[c] = _interp_inplace(s, tx)
+                s = _numeric(d, c)
+                d = d.with_columns(pl.Series(c, _interp_over_time(s, m, tx)))
             notes.append("Interpolated outliers linearly over time.")
         else:
             raise ValueError("outlier must be one of: 'none','drop','clip','interp'")
@@ -501,4 +570,4 @@ def clean(
         per_column_outliers=per_col,
         notes=notes,
     )
-    return d, rep
+    return _from_polars_eager(d, kind), rep

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from bdf.repair import (
@@ -184,7 +185,7 @@ def test_hampel_flags_spike_and_clean_series_flags_nothing():
     df = _smooth_df(spike_at=50)
     t = df["Test Time / s"]
     hampel = _hampel_mask(df["Voltage / V"], time_s=t, seconds=300.0, k=6.0)
-    assert bool(hampel.iloc[50])
+    assert bool(hampel[50])
     clean_v = _smooth_df()["Voltage / V"]
     assert not _hampel_mask(clean_v, time_s=t, seconds=300.0, k=6.0).any()
 
@@ -198,7 +199,7 @@ def test_slope_mask_needs_derivative_spread():
     # with any real spread in the derivative, the spike is flagged
     v = df["Voltage / V"] + 0.001 * np.sin(np.arange(len(df)))
     slope = _slope_mask(v, time_s=t, z=8.0)
-    assert bool(slope.iloc[50])
+    assert bool(slope[50])
 
 
 # ---- fix_time methods ----
@@ -357,3 +358,40 @@ def test_clean_report_str_contains_summary_lines():
     assert "Time fix: segment" in text
     assert "Outliers: drop (z>8)" in text
     assert "Per-column outliers: Voltage / V=1, Current / A=0" in text
+
+
+# ---- polars-native boundary (post-port) ----
+
+
+def test_clean_polars_in_polars_out():
+    df = pl.from_pandas(_smooth_df(spike_at=50))
+    out, rep = clean(df, time_fix="none", outlier="drop")
+    assert isinstance(out, pl.DataFrame)
+    assert rep.n_rows_out == 99
+
+
+def test_clean_lazy_in_lazy_out():
+    lf = pl.from_pandas(_smooth_df()).lazy()
+    out, rep = clean(lf, time_fix="segment", outlier="none")
+    assert isinstance(out, pl.LazyFrame)
+    assert rep.n_rows_out == 100
+
+
+def test_clean_pandas_in_pandas_out():
+    out, _ = clean(_smooth_df(), time_fix="none", outlier="none")
+    assert isinstance(out, pd.DataFrame)
+
+
+def test_fix_time_polars_in_polars_out():
+    df = pl.DataFrame({"Test Time / s": [0.0, 10.0, 3.0, 20.0]})
+    out = fix_time(df, method="segment")
+    assert isinstance(out, pl.DataFrame)
+    assert out["Test Time / s"].is_sorted()
+
+
+def test_clean_results_identical_across_kinds():
+    pdf = _smooth_df(spike_at=50)
+    out_pd, _ = clean(pdf, time_fix="segment", outlier="clip")
+    out_pl, _ = clean(pl.from_pandas(pdf), time_fix="segment", outlier="clip")
+    np.testing.assert_allclose(out_pd["Voltage / V"].to_numpy(), out_pl["Voltage / V"].to_numpy())
+    np.testing.assert_allclose(out_pd["Test Time / s"].to_numpy(), out_pl["Test Time / s"].to_numpy())


### PR DESCRIPTION
First half of the pandas removal I took per the work split (repair and validate are the two pandas-bound modules; validate follows once #70 lands so it only rebases once).

## What

- `fix_time` and `clean` accept polars (eager or lazy) or pandas frames and return the same kind. All numerics run on numpy arrays, so results are identical across input types; there's a test asserting pandas-in and polars-in produce byte-identical outputs.
- Rolling statistics (Hampel, local IQR z) moved from pandas rolling to polars rolling with NaN treated as missing, matching the previous semantics.
- `inplace` on `fix_time` keeps its meaning for pandas input and is documented as having no effect for immutable polars frames.
- The CLI clean command no longer round-trips through pandas (this also removes a leftover unused conversion).
- mypy re-enabled for `bdf.repair`.

## Verification

The #77 characterization suite passes unchanged in substance: every behavioral pin (exact eps values, window sizing, note strings, report fields, the negative-start rebase quirk, the slope-gate zero-spread guard) holds on the new internals. The only test edits are two private-helper accessors (`.iloc[50]` to `[50]`, the helpers now take numpy arrays) plus new boundary tests for the three frame kinds. 659 offline tests green, pinned mypy passes.