### PR TITLE
fix(arbin): map capacity/energy accumulators to schedule_* terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [Unreleased]
 ### Added
+- Arbin normalizers (csv, xlsx) map Charge/Discharge Capacity and Energy to the schedule_* terms from ontology 1.3.0, reflecting the operator-defined reset behavior Arbin confirmed; the columns previously landed on the never-resetting test-scoped terms.
 - CI pipeline with lint/type/tests/docs and build/twine checks.
 - Sphinx docs with pydata theme and converted notebook examples.
 - Unit tests for IO, registry, validation, repair, CLI, and raw conversion.

--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -685,10 +685,13 @@ ARBIN = TableNormalizer(
         Syn(hdr="Aux_Temperature_1 (C)"),
         Syn(hdr="Aux_Temperature_1 ({unit})"),
     ),
-    charging_capacity_ah=(Syn(hdr="Charge Capacity ({unit})"),),
-    discharging_capacity_ah=(Syn(hdr="Discharge Capacity ({unit})"),),
-    charging_energy_wh=(Syn(hdr="Charge Energy ({unit})"),),
-    discharging_energy_wh=(Syn(hdr="Discharge Energy ({unit})"),),
+    # Arbin accumulators reset at operator-defined schedule points (confirmed by
+    # Arbin's MITS team), so they map to the schedule-scoped terms from ontology
+    # 1.3.0, not the never-resetting test-scoped ones.
+    schedule_charging_capacity_ah=(Syn(hdr="Charge Capacity ({unit})"),),
+    schedule_discharging_capacity_ah=(Syn(hdr="Discharge Capacity ({unit})"),),
+    schedule_charging_energy_wh=(Syn(hdr="Charge Energy ({unit})"),),
+    schedule_discharging_energy_wh=(Syn(hdr="Discharge Energy ({unit})"),),
     power_watt=(Syn(hdr="Power ({unit})"),),
     ac_internal_resistance_ohm=(Syn(hdr="ACR ({unit})"),),
     dc_internal_resistance_ohm=(Syn(hdr="Internal Resistance ({unit})"),),

--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -685,8 +685,9 @@ ARBIN = TableNormalizer(
         Syn(hdr="Aux_Temperature_1 (C)"),
         Syn(hdr="Aux_Temperature_1 ({unit})"),
     ),
-    # Arbin accumulators reset at operator-defined schedule points (confirmed by
-    # Arbin's MITS team), so they map to the schedule-scoped terms from ontology
+    # Arbin's accumulators reset at operator-authored schedule points ('Set
+    # variable(s)') and can be assigned arbitrary values ('Set value'), per
+    # Arbin's MITS team, so they carry the schedule-scoped terms from ontology
     # 1.3.0, not the never-resetting test-scoped ones.
     schedule_charging_capacity_ah=(Syn(hdr="Charge Capacity ({unit})"),),
     schedule_discharging_capacity_ah=(Syn(hdr="Discharge Capacity ({unit})"),),

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -455,10 +455,10 @@ ALL_CASES: list[tuple[str, SampleCase]] = [
                 "step_id": ColExpect("Step Index", 1.0),
                 "record_index": ColExpect("Data Point", 1.0),
                 "step_time_second": ColExpect("Step Time (s)", 1.0),
-                "charging_capacity_ah": ColExpect("Charge Capacity (Ah)", 1.0),
-                "discharging_capacity_ah": ColExpect("Discharge Capacity (Ah)", 1.0),
-                "charging_energy_wh": ColExpect("Charge Energy (Wh)", 1.0),
-                "discharging_energy_wh": ColExpect("Discharge Energy (Wh)", 1.0),
+                "schedule_charging_capacity_ah": ColExpect("Charge Capacity (Ah)", 1.0),
+                "schedule_discharging_capacity_ah": ColExpect("Discharge Capacity (Ah)", 1.0),
+                "schedule_charging_energy_wh": ColExpect("Charge Energy (Wh)", 1.0),
+                "schedule_discharging_energy_wh": ColExpect("Discharge Energy (Wh)", 1.0),
                 "power_watt": ColExpect("Power (W)", 1.0),
                 "dc_internal_resistance_ohm": ColExpect("Internal Resistance (Ohm)", 1.0),
                 "ac_internal_resistance_ohm": ColExpect("ACR (Ohm)", 1.0),
@@ -467,26 +467,6 @@ ALL_CASES: list[tuple[str, SampleCase]] = [
             null_ok_columns=frozenset({"DC Internal Resistance / ohm", "AC Internal Resistance / ohm"}),
             known_validity_bugs={
                 "ac_internal_resistance_ohm": "ACR (Ohm) is entirely empty in this pulse-test export",
-                "charging_capacity_ah": (
-                    "Charge Capacity resets exactly once, at the step-9 boundary marking the "
-                    "end of initial conditioning and the start of the repeated pulse loop; "
-                    "globally cumulative everywhere else, so this is a single scripted "
-                    "counter reset in the test plan, not a per-step reset"
-                ),
-                "discharging_capacity_ah": (
-                    "Discharge Capacity resets at two specific steps (12 and 74) on every "
-                    "pass through the repeated pulse loop, not at the other ~60 step "
-                    "boundaries per loop; scripted resets at those two steps in the test "
-                    "plan, not a per-step reset"
-                ),
-                "charging_energy_wh": (
-                    "Charge Energy mirrors Charge Capacity: resets once at the step-9 "
-                    "boundary, globally cumulative elsewhere"
-                ),
-                "discharging_energy_wh": (
-                    "Discharge Energy mirrors Discharge Capacity: resets at specific steps "
-                    "within the repeated pulse loop, not at every step boundary"
-                ),
             },
             marks=(pytest.mark.network,),
         ),
@@ -581,10 +561,10 @@ ALL_CASES: list[tuple[str, SampleCase]] = [
                 # NOTE: the four vendor accumulator expectations below disappear when the
                 # accumulator-unmap change (fix/derived-tolerance-and-arbin-accumulators)
                 # merges; drop them during that rebase.
-                "charging_capacity_ah": ColExpect("Charge Capacity (Ah)", 1.0),
-                "discharging_capacity_ah": ColExpect("Discharge Capacity (Ah)", 1.0),
-                "charging_energy_wh": ColExpect("Charge Energy (Wh)", 1.0),
-                "discharging_energy_wh": ColExpect("Discharge Energy (Wh)", 1.0),
+                "schedule_charging_capacity_ah": ColExpect("Charge Capacity (Ah)", 1.0),
+                "schedule_discharging_capacity_ah": ColExpect("Discharge Capacity (Ah)", 1.0),
+                "schedule_charging_energy_wh": ColExpect("Charge Energy (Wh)", 1.0),
+                "schedule_discharging_energy_wh": ColExpect("Discharge Energy (Wh)", 1.0),
             },
             null_ok_columns=frozenset({"DC Internal Resistance / ohm", "AC Internal Resistance / ohm"}),
             known_validity_bugs={

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -558,9 +558,6 @@ ALL_CASES: list[tuple[str, SampleCase]] = [
                 "temperature_t1_celsius": ColExpect("Aux_Temperature_1 (C)", 1.0),
                 "dc_internal_resistance_ohm": ColExpect("Internal Resistance (Ohm)", 1.0),
                 "ac_internal_resistance_ohm": ColExpect("ACR (Ohm)", 1.0),
-                # NOTE: the four vendor accumulator expectations below disappear when the
-                # accumulator-unmap change (fix/derived-tolerance-and-arbin-accumulators)
-                # merges; drop them during that rebase.
                 "schedule_charging_capacity_ah": ColExpect("Charge Capacity (Ah)", 1.0),
                 "schedule_discharging_capacity_ah": ColExpect("Discharge Capacity (Ah)", 1.0),
                 "schedule_charging_energy_wh": ColExpect("Charge Energy (Wh)", 1.0),
@@ -569,12 +566,6 @@ ALL_CASES: list[tuple[str, SampleCase]] = [
             null_ok_columns=frozenset({"DC Internal Resistance / ohm", "AC Internal Resistance / ohm"}),
             known_validity_bugs={
                 "ac_internal_resistance_ohm": "ACR (Ohm) is entirely empty in this dynamic-load export",
-                # Schedule-authored accumulator resets (79 discharge / 1 charge, at scripted
-                # steps); removed along with the accumulator ColExpects at the unmap rebase.
-                "charging_capacity_ah": "Charge Capacity resets at schedule-defined steps",
-                "discharging_capacity_ah": "Discharge Capacity resets at schedule-defined steps",
-                "charging_energy_wh": "Charge Energy resets at schedule-defined steps",
-                "discharging_energy_wh": "Discharge Energy resets at schedule-defined steps",
             },
             marks=(
                 pytest.mark.network,

--- a/tests/integration/test_column_validity.py
+++ b/tests/integration/test_column_validity.py
@@ -555,6 +555,25 @@ class TestInstantaneousRangeCategorical:
     def test_dc_internal_resistance_ohm(self, cid: str, case: SampleCase, data_dir: Path) -> None:
         run_check(case, data_dir, "dc_internal_resistance_ohm", assert_nonneg_finite)
 
+    # schedule_* accumulators (ontology 1.3.0): resets and assignments are
+    # schedule-defined and legal anywhere, so the only assertable invariants
+    # are finiteness and non-negativity.
+    @pytest.mark.parametrize("cid,case", cases_for("schedule_charging_capacity_ah"))
+    def test_schedule_charging_capacity_ah(self, cid: str, case: SampleCase, data_dir: Path) -> None:
+        run_check(case, data_dir, "schedule_charging_capacity_ah", assert_nonneg_finite)
+
+    @pytest.mark.parametrize("cid,case", cases_for("schedule_discharging_capacity_ah"))
+    def test_schedule_discharging_capacity_ah(self, cid: str, case: SampleCase, data_dir: Path) -> None:
+        run_check(case, data_dir, "schedule_discharging_capacity_ah", assert_nonneg_finite)
+
+    @pytest.mark.parametrize("cid,case", cases_for("schedule_charging_energy_wh"))
+    def test_schedule_charging_energy_wh(self, cid: str, case: SampleCase, data_dir: Path) -> None:
+        run_check(case, data_dir, "schedule_charging_energy_wh", assert_nonneg_finite)
+
+    @pytest.mark.parametrize("cid,case", cases_for("schedule_discharging_energy_wh"))
+    def test_schedule_discharging_energy_wh(self, cid: str, case: SampleCase, data_dir: Path) -> None:
+        run_check(case, data_dir, "schedule_discharging_energy_wh", assert_nonneg_finite)
+
     @pytest.mark.parametrize("cid,case", cases_for("temperature_t1_celsius"))
     def test_temperature_t1_celsius(self, cid: str, case: SampleCase, data_dir: Path) -> None:
         run_check(case, data_dir, "temperature_t1_celsius", assert_temp_range)


### PR DESCRIPTION
The Arbin remap step from the release plan.

Arbin's Charge/Discharge Capacity/Energy columns reset at operator-defined schedule points and can be assigned arbitrary values (confirmed by their MITS team), which is why ontology 1.3.0 added the schedule_* terms. This maps the shared ARBIN normalizer (arbin_csv + arbin_xlsx) onto them, updates the integration expectations, removes the reset waivers that are legal behavior under the schedule-scoped semantics, and wires the schedule_* quantities into the validity suite (nonneg-finite family).

**Note on provenance**: after opening this I found Simon's pre-handoff branch feat/ontology-1.3.0-sync contains the same remap, prepared July 20. The two versions are substantively identical; this PR adopts his comment wording and his cleanup of the stale arbin_xlsx waivers, so his branch can be retired once this merges. Credit to Simon for getting there first.

Verified end to end against the real Zenodo Arbin pulse export (131,884 rows): all four accumulators land on the Schedule labels. #60's .res normalizer got the same treatment on its own branch.