### PR TITLE
fix(arbin_res): mark synonyms assumed until a .res sample lands

### DIFF
--- a/src/bdf/table_normalizers.py
+++ b/src/bdf/table_normalizers.py
@@ -706,10 +706,13 @@ ARBIN = TableNormalizer(
     dc_internal_resistance_ohm=(Syn(hdr="Internal Resistance ({unit})"),),
 )
 
+# All synonyms are assumed=True until a .res sample lands in the test corpus
+# (Abbta's CC-BY file from PR #60 is the candidate; tracked in the follow-up
+# issue). The synonym-coverage gate requires recorded headers otherwise.
 ARBIN_RES = TableNormalizer(
-    test_time_second=(Syn(hdr="Test_Time", source_unit="s"),),
-    voltage_volt=(Syn(hdr="Voltage", source_unit="V"),),
-    current_ampere=(Syn(hdr="Current", source_unit="A"),),
+    test_time_second=(Syn(assumed=True, hdr="Test_Time", source_unit="s"),),
+    voltage_volt=(Syn(assumed=True, hdr="Voltage", source_unit="V"),),
+    current_ampere=(Syn(assumed=True, hdr="Current", source_unit="A"),),
     # Access day-fraction datetimes are naive local wall-clock; this fixed
     # scale/offset treats them as UTC (no tz support on the ResolvedColumn
     # path). Acceptable for the .res use case; revisit if tz-correct absolute
@@ -719,20 +722,20 @@ ARBIN_RES = TableNormalizer(
         scale=_SECONDS_PER_DAY,
         offset=-_ACCESS_UNIX_EPOCH_DAYS * _SECONDS_PER_DAY,
     ),
-    cycle_count=(Syn(hdr="Cycle_Index"),),
-    step_id=(Syn(hdr="Step_Index"),),
-    record_index=(Syn(hdr="Data_Point"),),
-    step_time_second=(Syn(hdr="Step_Time", source_unit="s"),),
+    cycle_count=(Syn(assumed=True, hdr="Cycle_Index"),),
+    step_id=(Syn(assumed=True, hdr="Step_Index"),),
+    record_index=(Syn(assumed=True, hdr="Data_Point"),),
+    step_time_second=(Syn(assumed=True, hdr="Step_Time", source_unit="s"),),
     # Arbin accumulators reset at operator-defined schedule points, so they map
     # to the schedule-scoped terms from ontology 1.3.0 (see the csv/xlsx
     # normalizer above).
-    schedule_charging_capacity_ah=(Syn(hdr="Charge_Capacity", source_unit="Ah"),),
-    schedule_discharging_capacity_ah=(Syn(hdr="Discharge_Capacity", source_unit="Ah"),),
-    schedule_charging_energy_wh=(Syn(hdr="Charge_Energy", source_unit="Wh"),),
-    schedule_discharging_energy_wh=(Syn(hdr="Discharge_Energy", source_unit="Wh"),),
-    dc_internal_resistance_ohm=(Syn(hdr="Internal_Resistance", source_unit="ohm"),),
-    absolute_impedance_ohm=(Syn(hdr="AC_Impedance", source_unit="ohm"),),
-    phase_degree=(Syn(hdr="ACI_Phase_Angle", source_unit="degree"),),
+    schedule_charging_capacity_ah=(Syn(assumed=True, hdr="Charge_Capacity", source_unit="Ah"),),
+    schedule_discharging_capacity_ah=(Syn(assumed=True, hdr="Discharge_Capacity", source_unit="Ah"),),
+    schedule_charging_energy_wh=(Syn(assumed=True, hdr="Charge_Energy", source_unit="Wh"),),
+    schedule_discharging_energy_wh=(Syn(assumed=True, hdr="Discharge_Energy", source_unit="Wh"),),
+    dc_internal_resistance_ohm=(Syn(assumed=True, hdr="Internal_Resistance", source_unit="ohm"),),
+    absolute_impedance_ohm=(Syn(assumed=True, hdr="AC_Impedance", source_unit="ohm"),),
+    phase_degree=(Syn(assumed=True, hdr="ACI_Phase_Angle", source_unit="degree"),),
 )
 
 BASYTEC = TableNormalizer(


### PR DESCRIPTION
Fixes the main CI break from #60's merge. The synonym-coverage gate requires recorded headers from real sample cases, and the corpus has no .res sample (the plugin's tests are mocked). This surfaced only on main because fork-PR CI required maintainer approval and never actually ran on the final pushes; the pre-merge green was stale.

assumed=True is exactly what the coverage mechanism defines for synonyms without sample data. Follow-up issue coming to wire Abbta's CC-BY .res file into the corpus and flip these back.