### PR TITLE
CLI: stdin/stdout piping for convert and validate, diagnostics to stderr

### DIFF
--- a/src/bdf/cli.py
+++ b/src/bdf/cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import tempfile
 from pathlib import Path
 from typing import List, Optional
 
@@ -19,6 +21,16 @@ from .repair import DEFAULT_OUTLIER_COLS, clean as clean_bdf
 from .visualize import X_DEFAULT, Y_DEFAULT, plot as line_plot
 
 app = typer.Typer(help="Battery Data Format utilities")
+
+
+def _stdin_to_tmp() -> Path:
+    """Buffer stdin into a temp file so the detection pipeline can seek and reread it."""
+    data = sys.stdin.buffer.read()
+    if not data:
+        raise typer.BadParameter("stdin is empty")
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(data)
+    return Path(tmp.name)
 
 
 def _version_callback(value: bool) -> None:
@@ -177,7 +189,7 @@ def meta_jsonld(
             df = None  # okay: JSON-LD will omit per-column metadata
 
     out_path = save_jsonld(meta, data, out_path=out, df=df, csvw_schema_url=schema_url)
-    typer.echo(f"Wrote metadata: {out_path}")
+    typer.echo(f"Wrote metadata: {out_path}", err=True)
 
 
 @app.command()
@@ -200,20 +212,24 @@ def clean(
     df, rep = clean_bdf(df, time_fix=time_fix, outlier=outlier, z_thresh=z, columns=col)
     save(df, out)
     typer.echo(str(rep))
-    typer.echo(f"Saved: {out}")
+    typer.echo(f"Saved: {out}", err=True)
 
 
 @app.command()
 def validate(
-    path: str,
+    path: str = typer.Argument(..., help="File to validate, or '-' to read from stdin"),
     strict: bool = typer.Option(False, help="Raise error (non-zero exit) on invalid BDF"),
     json: bool = typer.Option(False, help="Output machine-readable JSON report"),
 ):
     """
     Validate a CSV/Parquet file against the BDF schema and basic sanity checks.
+
+    The report goes to stdout; operational errors go to stderr.
+    Exit codes: 0 valid, 1 invalid, 2 could not read the input.
     """
+    src: str | Path = _stdin_to_tmp() if path == "-" else path
     try:
-        report = validate_any(path, report=not json, raise_on_error=strict)
+        report = validate_any(src, report=not json, raise_on_error=strict)
     except BDFValidationError as e:
         if json:
             import json as _json
@@ -223,8 +239,11 @@ def validate(
             print(f"[bdf] INVALID\n{e}")
         raise typer.Exit(code=1) from None
     except Exception as e:
-        print(f"[bdf] Error reading file: {e}")
+        typer.echo(f"[bdf] Error reading file: {e}", err=True)
         raise typer.Exit(code=2) from e
+    finally:
+        if path == "-":
+            Path(src).unlink(missing_ok=True)
 
     ok = bool(report.get("ok"))
     if json:
@@ -275,8 +294,8 @@ def templates(
 
 @app.command()
 def convert(
-    path: str,
-    to: str = "bdf.csv",
+    path: str = typer.Argument(..., help="Raw vendor file or BDF artifact, or '-' to read from stdin"),
+    to: str = typer.Option("bdf.csv", "--to", help="Output path, or '-' to write BDF CSV to stdout"),
     as_: Optional[str] = typer.Option(None, "--as", help="Force a specific plugin id for raw input"),
     include_unknown: bool = typer.Option(
         False, "--include-unknown", help="Keep columns outside the BDF spec in the output"
@@ -291,15 +310,30 @@ def convert(
 ):
     """
     Convert a raw vendor file or existing BDF artifact to another BDF artifact.
+
+    Data goes to the output path (stdout with '--to -'); status messages go to stderr.
+    Stdin input has no filename, so detection relies on content; use --as if it is ambiguous.
     """
     if human is not None:
         labels = "preferred" if human else "machine"
     if labels not in ("preferred", "machine", "unchanged"):
         raise typer.BadParameter("--labels must be one of: preferred, machine, unchanged")
 
-    df, _ = read(path, plugin=as_, validate=validate, include_unknown=include_unknown)
-    save(df, to, validate=validate, labels=labels)
-    print(f"[bdf] wrote {to}")
+    src: str | Path = _stdin_to_tmp() if path == "-" else path
+    try:
+        df, _ = read(src, plugin=as_, validate=validate, include_unknown=include_unknown)
+    finally:
+        if path == "-":
+            Path(src).unlink(missing_ok=True)
+
+    if to == "-":
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "out.bdf.csv"
+            save(df, out, validate=validate, labels=labels)
+            sys.stdout.buffer.write(out.read_bytes())
+    else:
+        save(df, to, validate=validate, labels=labels)
+        typer.echo(f"[bdf] wrote {to}", err=True)
 
 
 @app.command()
@@ -323,4 +357,4 @@ def plot(
 
     # Draw the plot
     line_plot(df, xdata=xdata, ydata=ydata, save=save, show=show, title=f"{', '.join(ydata)} vs {xdata}")
-    print(f"[bdf] plotted {', '.join(ydata)} vs {xdata}" + (f" -> {save}" if save else ""))
+    typer.echo(f"[bdf] plotted {', '.join(ydata)} vs {xdata}" + (f" -> {save}" if save else ""), err=True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -134,3 +134,38 @@ def test_cli_ingest_existing_bdf(tmp_path: Path, monkeypatch):
     assert res.exit_code == 0
     out = root / "timeseries" / "sample.bdf.csv"
     assert out.exists()
+
+
+_SAMPLE_CSV = "Test Time / s,Voltage / V,Current / A\n0,3.7,0.1\n1,3.6,0.1\n2,3.5,0.1\n"
+
+
+def test_cli_validate_stdin():
+    ok = runner.invoke(app, ["validate", "-"], input=_SAMPLE_CSV)
+    assert ok.exit_code == 0
+
+    fail = runner.invoke(app, ["validate", "-"], input="garbage,,\n1,2\n")
+    assert fail.exit_code != 0
+
+
+def test_cli_validate_json_stdout_is_pure_json():
+    res = runner.invoke(app, ["validate", "-", "--json"], input=_SAMPLE_CSV)
+    assert res.exit_code == 0
+    report = json.loads(res.stdout)
+    assert report["ok"] is True
+
+
+def test_cli_convert_stdin_to_stdout():
+    res = runner.invoke(app, ["convert", "-", "--to", "-"], input=_SAMPLE_CSV)
+    assert res.exit_code == 0
+    lines = res.stdout.strip().splitlines()
+    assert lines[0] == "test_time_second,voltage_volt,current_ampere"
+    assert len(lines) == 4
+
+
+def test_cli_convert_status_goes_to_stderr(tmp_path: Path):
+    src = _make_sample_bdf(tmp_path)
+    out = tmp_path / "piped.bdf.csv"
+    res = runner.invoke(app, ["convert", str(src), "--to", str(out)])
+    assert res.exit_code == 0
+    assert out.exists()
+    assert "wrote" not in res.stdout


### PR DESCRIPTION
Completes the CLI composability item I claimed on the 0.2.0 thread (exit codes / stderr / piping). Exit codes and --json already existed, so this adds the remaining two pieces:

- `convert` and `validate` accept `-` to read from stdin. Input is buffered to a temp file so the content-detection pipeline can seek; with no filename, detection skips the ext stage and falls to magic bytes and columns. `--as` forces a plugin if content is ambiguous.
- `convert --to -` writes BDF CSV to stdout, with all status messages on stderr, so output pipes cleanly:

```
cat data.csv | bdf convert - --to - | head
bdf validate data.bdf.csv --json | jq .ok
```

- Status lines in `clean`, `meta-jsonld`, and `plot` also move to stderr. Reports (validate human/JSON, clean report) stay on stdout. Exit codes unchanged: 0 valid, 1 invalid, 2 unreadable.

No changes to the Python API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)