### PR TITLE
Update changelog for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,77 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - Unreleased
+### Breaking
+- Dropped Python 3.9 support; now requires Python ≥3.10 (tested through 3.14).
+- `read()` gives a `(polars.DataFrame, metadata)` tuple, replacing the old pandas `read(...) -> pandas.DataFrame`.
+- New `scan()` gives a `(polars.LazyFrame, metadata)` tuple.
+- `load()` removed, use `read()` or `scan()` for all files (BDF or non-BDF).
+- `read`/`scan` signature changed:
+  - `source` → `path`
+  - `registry_path` removed.
+  - `include_optional` removed — optional BDF columns are now always kept.
+  - `extra_columns` (extra column mapping dict) removed
+  - `include_unknown` added, keeps all non-spec columns in the dataframe under their original names (default `False`).
+  - `tz` kwarg added for naive datetimes.
+- `parse()` is removed — use `read(path, normalize=False, validate=False)`.
+- `save()` rewritten on Polars with more files supported, a `validate` kwarg, and a `labels` option (`"preferred" | "machine" | "unchanged"`) replacing the old `human=True/False` toggle. The `.metadata.json` sidecar behavior is unchanged.
+- `save()` to JSON previously output NDJSON, which cannot be read by standard JSON parsers. These are now two distinct options, save to ".ndjson" to get newline-delimited JSON.
+- Top-level `plugins()` function removed; use `bdf.plugins.list_sources()` instead.
+- `ingest()` gets the same kwarg changes as `read`/`scan`/`save`: `include_optional` removed, `include_unknown` added, and `human: bool = False` → `labels: Literal["preferred", "machine", "unchanged"] = "machine"`.
+- `ingest` CLI: `--include-optional` removed, `--include-unknown` added, `--labels` option added.
+- CLI: `clean` and `plot` no longer take `--assume-bdf`.
+- Column spec is now ontology-driven (`bdf.spec.ColumnOntology`, synced from the published BDF ontology release); `bdf.normalize`, `bdf.units`, `bdf.detect`, and `bdf.data_sources` are removed in favor of `bdf.plugins`, `bdf.table_parsers`, `bdf.metadata_parsers`, and `bdf.table_normalizers`.
+- `fastnda` install extra renamed to `nda`.
+- Module paths `bdf.validate`, `bdf.templates`, and `bdf.ingest` renamed to private submodules; the `validate()`, `templates()`, and `ingest()` functions are unchanged and remain importable from the `bdf` namespace. Fixes module/function name collisions.
+- `Quantity.unit_conversion` renamed to `convert_to`.
+- Arbin normalizers (csv, xlsx) map Charge/Discharge Capacity and Energy to the `schedule_*` columns (`Schedule Charging Capacity / Ah`, ...) from ontology 1.3.0, reflecting the operator-defined reset behavior Arbin confirmed; these columns previously landed on the never-resetting test-scoped terms.
+- `read()`/`scan()` raise `BDFValidationError` when an elapsed-time column's increments disagree with the recorded timestamps (e.g. milliseconds stored under a seconds header); pass `reconcile_time=True` to repair known unit factors or `validate=False` to load the data as-is.
+
 ### Added
-- validate.py ported to polars-native internals: validate_df accepts polars (eager or lazy) or pandas frames with identical reports across input types; the validate() artifact path no longer converts to pandas. Completes the repair/validate pandas removal.
-- Time reconciliation on read (GH #65): `bdf.read` cross-checks `Test Time / s` and `Step Time / s` increments against wall-clock (`Unix Time / s`) increments; a column stored in the wrong unit under a seconds header (e.g. a Digatron export holding milliseconds) is rescaled to seconds, recorded under `metadata["time_reconciliation"]`, and announced with a `UserWarning`. Disable with `reconcile_time=False`. `bdf.validate` reports the same mismatch as a `time_scale` finding without modifying data.
-- repair.py ported to polars-native internals: fix_time and clean now accept polars (eager or lazy) or pandas frames and return the same kind, with identical numeric results across input types (pinned by the characterization suite). mypy re-enabled on the module; the CLI clean command no longer round-trips through pandas.
-- Arbin normalizers (csv, xlsx) map Charge/Discharge Capacity and Energy to the schedule_* terms from ontology 1.3.0, reflecting the operator-defined reset behavior Arbin confirmed; the columns previously landed on the never-resetting test-scoped terms.
+- BDF parsers/normalizers for BDF JSON, NDJSON, Arrow/Feather (IPC), XLSX.
+- Arbin MITS XLSX parser.
+- Arbin `.res` parser (Access/MDB, via pyodbc on Windows or MDB Tools elsewhere; `arbin_res` extra). Contributed by @Abbta.
+- BioLogic `.mpr` binary parser via yadg (`mpr` extra), including the EIS quantities; adds a `reverse_sign` option to normalizer synonyms.
+- PyBaMM simulation-output table normalizer (`pybamm` plugin).
+- `validate` now checks ontology-defined derived-column consistency.
+- Time-scale detection (GH #65): elapsed-time columns are cross-checked against wall-clock increments on read, following the fsck model (detect loudly by default, repair only with the explicit `reconcile_time=True` flag; repairs are recorded under `metadata["time_reconciliation"]`). `validate` reports the same mismatch as a `time_scale` finding.
+- Ontology 1.3.0: `schedule_*` capacity/energy terms for schedule-driven accumulators and `step_record_index` (replacing the deprecated `step_index`).
+- Ontology release pinning with a bundled snapshot, `BDF_CACHE_DIR` cache override, and a daily auto-sync workflow.
+- New optional extras `excel`, `mat`, `mpr`, `yaml` for additional file formats, and an `all` bundle covering all user-facing feature extras.
+- CLI piping: `convert` and `validate` accept `-` to read from stdin, and `convert --to -` writes BDF CSV to stdout; status messages go to stderr. Exit codes: 0 valid, 1 invalid, 2 unreadable.
+- Docs: example notebooks now execute live via myst-nb, plus a generated "Supported Plugins" reference page.
+
+### Changed
+- I/O layer rebuilt on Polars.
+- `repair` and `validate` rebuilt on Polars: `fix_time`, `clean`, and `validate_df` accept polars (eager or lazy) or pandas frames and return matching kinds, with identical results across input types; the CLI no longer round-trips through pandas.
+- Dev and docs dependencies moved to PEP 735 dependency-groups; plotting deps moved into a new `plot` extra.
+- `save()` now validates via `ColumnOntology.validate_df`, which also warns on non-canonical BDF units.
+- `ColumnOntology.load_version()` now fetches and caches an uncached ontology release instead of raising.
+- `NDAParser` renamed to `NdaParser`; its magic-byte check now recognizes the `.ndax` zip container.
+- Package import is lazy: `import bdf` completes in ~0.15 s without loading pandas/polars/scipy; heavy dependencies import on first use, making CLI startup near-instant.
+- `save()` names the metadata sidecar by replacing the final extension (`x.bdf.parquet` -> `x.bdf.metadata.json`) instead of appending to the full filename.
+
+### Fixed
+- `arbin_res` extra is now part of the `all` bundle, and its mdbtools backend supports Python 3.10 (polars-access-mdbtools 0.1.3).
+- Unix-time conversion is now datetime-resolution-safe: previously assumed nanosecond storage and returned values 1000x too small on pandas builds that yield `[us]`/`[s]`/`[ms]` datetimes.
+- `ingest` now lowercases the cell id in per-cell metadata directory paths, stable on case-sensitive filesystems.
+- Compound file extensions (e.g. `.bdf.csv.gz`) no longer fail to match a plugin.
+- Daylight-saving-time handling in naive-datetime parsing.
+- Special characters can be used in units.
+- `ohm` and `degC` are accepted as units.
+- Deprecated-column redirection (read/load/save) now follows the ontology's `isReplacedBy` link, fixing silent data loss/mislabeling for renamed legacy columns (e.g. `step_capacity_ah` → `step_cumulative_capacity_ah`).
+- Excel parser raises on ambiguous `sheet_pattern` matches instead of silently reading only the first matching sheet.
+- BDF table normalizer now accepts machine-notation and deprecated on-disk headers, fixing read/validate round-trips of default `save()` artifacts.
+- `validate()` now uses plugin detection to decide whether a file is a BDF artifact.
+- `.json` artifacts are now valid standalone JSON (a records array via `write_json`); previously `save()` wrote JSON-Lines under the `.json` extension, producing files that failed to parse as JSON outside pandas. Use the new `.ndjson` format for JSON-Lines output.
+
+### Known limitations
+- `save()` writes a `.metadata.json` sidecar that `read()` does not yet read back; the typed metadata object (GH #48, tracked in #91) will close the loop.
+
+## [0.1.0] - 2026-02-10
+### Added
 - CI pipeline with lint/type/tests/docs and build/twine checks.
 - Sphinx docs with pydata theme and converted notebook examples.
 - Unit tests for IO, registry, validation, repair, CLI, and raw conversion.
@@ -21,7 +87,3 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 - Improved README with install/quickstart and CLI examples.
 - Relaxed numpy upper bound and added a numpy2 install extra.
 - Switched PyPI distribution name from `bdf` to `batterydf` (import/CLI remain `bdf`).
-
-### Fixed
-- Unix-time conversion is now datetime-resolution-safe: `bdf.time.parse_unix_time` computed epoch seconds via `astype("int64") / 1e9`, which assumed nanosecond storage and returned values 1000× too small on pandas builds that yield `[us]`/`[s]`/`[ms]` datetimes (e.g. newer Python/pandas in CI). Now uses timedelta arithmetic (`(dt - epoch).dt.total_seconds()`), correct for any resolution.
-- `bdf.ingest` now lowercases the cell id when creating the per-cell metadata directory, so generated paths are stable on case-sensitive filesystems (the cell `metadata.jsonld` was previously written to a differently-cased directory on Linux).


### PR DESCRIPTION
Carries the final content of #80 verbatim (byte-identical CHANGELOG.md), rebuilt as one signed commit. #80 had a single unsigned commit buried mid-history behind several merge commits; rather than rewrite shared history or override the DCO check, this supersedes it with clean provenance. Authored with @g-kimbell, credited in the commit.

Closes #80's content into main; #80 itself is closed with a pointer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)