### PR TITLE
Re-land #57: reference-data gates (merge was recorded but never reached main)

### DIFF
--- a/scripts/generate_zenodo_reference_bdf.py
+++ b/scripts/generate_zenodo_reference_bdf.py
@@ -293,6 +293,7 @@ class CaseResult:
     rows: int | None = None
     cols: int | None = None
     error: str | None = None
+    derived_issues: list[str] | None = None
 
 
 def _output_path(
@@ -345,6 +346,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--human", action="store_true", help="Write human-prefLabel headers instead of machine labels.")
     parser.add_argument("--fail-fast", action="store_true")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any generated file has derived-column inconsistencies.",
+    )
     return parser.parse_args()
 
 
@@ -433,6 +439,10 @@ def main() -> int:
             df, _ = bdf.read(local_file, plugin=plugin, validate=False)
             out_path.parent.mkdir(parents=True, exist_ok=True)
             bdf.save(df, out_path, labels="preferred" if args.human else "machine")
+            # Gate: never publish reference data that contradicts the ontology's
+            # derived-column definitions (mislabeled step ids, swapped
+            # cumulative/net, non-monotonic cumulative/cycle_count, etc.).
+            derived_issues = bdf.validate_df(df, report=False, raise_on_error=False)["derived"]["issues"]
             results.append(
                 CaseResult(
                     source=str(case.get("source")),
@@ -442,9 +452,15 @@ def main() -> int:
                     plugin=plugin,
                     rows=int(len(df)),
                     cols=int(len(df.columns)),
+                    derived_issues=derived_issues or None,
                 )
             )
-            print(f"[ok] {download_url} -> {out_path}")
+            if derived_issues:
+                print(f"[warn] {out_path.name}: {len(derived_issues)} derived-column issue(s):")
+                for msg in derived_issues:
+                    print(f"         - {msg}")
+            else:
+                print(f"[ok] {download_url} -> {out_path}")
         except Exception as exc:
             results.append(
                 CaseResult(
@@ -463,6 +479,7 @@ def main() -> int:
     ok = sum(1 for r in results if r.status == "ok")
     failed = sum(1 for r in results if r.status == "failed")
     skipped = sum(1 for r in results if r.status == "skipped_exists")
+    noncompliant = sum(1 for r in results if r.derived_issues)
 
     manifest = {
         "registry_url": args.registry_url,
@@ -470,14 +487,25 @@ def main() -> int:
         "output_dir": str(output_dir),
         "cache_dir": str(cache_dir),
         "human_headers": bool(args.human),
-        "summary": {"total": len(results), "ok": ok, "failed": failed, "skipped_exists": skipped},
+        "summary": {
+            "total": len(results),
+            "ok": ok,
+            "failed": failed,
+            "skipped_exists": skipped,
+            "noncompliant": noncompliant,
+        },
         "results": [asdict(r) for r in results],
     }
     manifest_path = output_dir / "manifest.json"
     manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
     print(f"Wrote manifest: {manifest_path}")
-    print(f"Summary: ok={ok} failed={failed} skipped_exists={skipped}")
-    return 1 if failed else 0
+    print(f"Summary: ok={ok} failed={failed} skipped_exists={skipped} noncompliant={noncompliant}")
+    if failed:
+        return 1
+    if args.strict and noncompliant:
+        print(f"Strict mode: {noncompliant} file(s) have derived-column inconsistencies; failing.")
+        return 2
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/bdf/spec.py
+++ b/src/bdf/spec.py
@@ -40,6 +40,23 @@ if TYPE_CHECKING:
 
 _SLUG = re.compile(r"[^a-z0-9]+")
 _REQUIRED_DEFAULT = {"test_time_second", "voltage_volt", "current_ampere"}
+
+# Generic-recognition disambiguation for vendor headers whose naive
+# label/notation slug resolves to the wrong quantity. Applied last (winning)
+# in base_synonym_index. Rationale, per the ontology's own definitions:
+#   - A raw column literally named "Step Index" / "Step_Index" is the program
+#     step identifier (Arbin Step_Index, Digatron Step, BioLogic Ns) => step_id,
+#     NOT the per-step record counter. Without this override the deprecated
+#     step_index synonym redirects the slug to step_record_index via
+#     isReplacedBy, silently relabeling vendor step ids. Canonically labelled
+#     data ("Step Record Index / 1") still resolves via exact-label paths.
+#   - "Step", "Ns", and "Cycle Index" were previously unmapped; map them here.
+_VENDOR_SYNONYM_OVERRIDES: dict[str, str] = {
+    "step-index": "step_id",
+    "step": "step_id",
+    "ns": "step_id",
+    "cycle-index": "cycle_count",
+}
 _UNIT_ALIAS = {
     "celsius": "degC",
     "degree_celsius": "degC",
@@ -617,6 +634,11 @@ class ColumnOntology:
                 slug = _slugify(str(base))
                 if slug:
                     idx.setdefault(slug, q_name)
+        # Apply vendor-header disambiguation last so it wins over the naive
+        # label/notation slugs (see _VENDOR_SYNONYM_OVERRIDES).
+        for slug, q_name in _VENDOR_SYNONYM_OVERRIDES.items():
+            if q_name in self._quantities:
+                idx[slug] = q_name
         return idx
 
     def required_labels(self) -> tuple[str, ...]:

--- a/tests/integration/test_reference_data_valid.py
+++ b/tests/integration/test_reference_data_valid.py
@@ -1,0 +1,62 @@
+"""Gate: reference example data must satisfy the ontology's derived-column rules.
+
+The ``docs/examples/reference/*.bdf.csv`` files are downloaded verbatim from
+Zenodo (see ``scripts/generate_zenodo_reference_bdf.py``). Some historical
+uploads are internally inconsistent with the ontology's derived-column
+definitions (mislabeled ``step_index``, swapped ``cumulative``/``net`` columns,
+a ``cycle_count`` equal to 2*pi, etc.). Those known-bad files are tracked in
+``KNOWN_NONCOMPLIANT`` with their issue references.
+
+This test enforces two things:
+  1. Any reference file NOT in the known-bad set must be clean -- so newly
+     added or refreshed reference data cannot silently introduce the same
+     class of corruption.
+  2. Any file IN the known-bad set must still be non-compliant -- so once a
+     file is fixed upstream, this test fails and reminds us to drop it from
+     the allowlist.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bdf import validate_df
+
+REFERENCE_DIR = Path(__file__).resolve().parents[2] / "docs" / "examples" / "reference"
+
+# filename -> tracking issue(s). See #52 for the audit.
+KNOWN_NONCOMPLIANT: dict[str, str] = {
+    "FZJ__INR21700__20250606__HPPC__25degC__Digatron.bdf.csv": "#54, #55, #56",
+    "SINTEF__LiGrR2032__2024-04-30__25degC__Landt.bdf.csv": "#54",
+    "SINTEF__G20M7-202512-Gru6mV__20251228__C30__25degC__Neware.bdf.csv": "#54, #56",
+    "SINTEF__SLPBA842124HV__2024-10-23__Rate_25degC__Neware__Time_Bug.bdf.csv": "#54",
+    "SINTEF__NaCR32140-MP10-04__2025-08-25__CCCV_0p02C_25degC__BioLogic__Outlier_Bug.bdf.csv": "#55",
+    "SINTEF__NaCR32140-MP10-04__2025-08-25__GITT_0p05C_25degC__BioLogic.bdf.csv": "#55",
+}
+
+
+def _reference_files() -> list[Path]:
+    return sorted(REFERENCE_DIR.glob("*.bdf.csv"))
+
+
+def _derived_issues(path: Path) -> list[str]:
+    df = pd.read_csv(path)
+    rep = validate_df(df, report=False, raise_on_error=False)
+    return rep["derived"]["issues"]
+
+
+@pytest.mark.skipif(not _reference_files(), reason="no reference data present")
+@pytest.mark.parametrize("path", _reference_files(), ids=lambda p: p.name)
+def test_reference_file_derived_consistency(path: Path) -> None:
+    issues = _derived_issues(path)
+    if path.name in KNOWN_NONCOMPLIANT:
+        # Known-bad: must still be non-compliant. When fixed upstream this
+        # assertion fails -> remove the file from KNOWN_NONCOMPLIANT.
+        assert issues, (
+            f"{path.name} is now clean; remove it from KNOWN_NONCOMPLIANT (tracked in {KNOWN_NONCOMPLIANT[path.name]})."
+        )
+    else:
+        assert not issues, f"{path.name} violates ontology-defined derived-column rules:\n  - " + "\n  - ".join(issues)

--- a/tests/unit/test_spec_ontology.py
+++ b/tests/unit/test_spec_ontology.py
@@ -461,6 +461,26 @@ def test_base_synonym_index_includes_label_notation_and_synonyms() -> None:
     assert idx["alias-two"] == "custom_q"
 
 
+def test_base_synonym_index_vendor_step_disambiguation() -> None:
+    """A raw 'Step Index'/'Step'/'Ns' header must resolve to step_id, not a record counter.
+
+    Per the ontology, 'Step Index' (Arbin), 'Step' (Digatron) and 'Ns' (BioLogic)
+    are program step identifiers (step_id). Without the override, the deprecated
+    step_index synonym redirects the 'step-index' slug to step_record_index via
+    isReplacedBy, silently relabeling vendor step ids as per-step record
+    counters. Canonically labelled data ('Step Record Index / 1') must still
+    resolve to step_record_index.
+    """
+    idx = spec.COLUMN_ONTOLOGY.base_synonym_index()
+    assert idx["step-index"] == "step_id"
+    assert idx["step"] == "step_id"
+    assert idx["ns"] == "step_id"
+    assert idx["cycle-index"] == "cycle_count"
+    # canonical step_record_index label ("Step Record Index / 1") is unaffected
+    assert idx["step-record-index-1"] == "step_record_index"
+    assert idx["step-record-index"] == "step_record_index"
+
+
 @pytest.mark.parametrize(
     ("label", "expected"),
     [


### PR DESCRIPTION
#57 shows as merged, but its merge commit (6f4c7af1) is unreachable from main. The repo activity log shows why: #75 and #57 were merged five seconds apart on Aug 12, both merge commits were computed against the same base, #75's ref update won, and #57's was dropped while the PR still flipped to merged. Only two pushes hit main that day, neither carrying #57.

This re-lands the exact reviewed commit (19a65e5, cherry-picked, sign-off intact): the vendor-header disambiguation override, the generator validation gate, and the reference-data CI ratchet. No changes from the reviewed content; 179 tests covering it pass locally on top of current main.

Process fix on my side: merge watchers now verify the merge commit is reachable from main after every merge, not just that gh reported success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)