### PR TITLE
Fix/download temp file cross filesystem

### DIFF
--- a/src/bdf/fetch.py
+++ b/src/bdf/fetch.py
@@ -79,14 +79,31 @@ def _safe_cache_name(url: str, filename: Optional[str]) -> str:
 
 
 def _download(url: str, dest: Path, timeout: int = 120) -> None:
-    with requests.get(url, stream=True, timeout=timeout) as r:
-        r.raise_for_status()
-        with tempfile.NamedTemporaryFile(delete=False) as tmp:
-            for chunk in r.iter_content(chunk_size=1 << 20):
-                if chunk:
-                    tmp.write(chunk)
-            tmp_path = Path(tmp.name)
-    tmp_path.replace(dest)
+    """Download ``url`` to ``dest`` through a temporary file in the same directory.
+
+    A rename is atomic only inside one filesystem. The system temporary
+    directory is often on another filesystem, so the temporary file must sit
+    beside ``dest``.
+
+    Args:
+        url: Source URL.
+        dest: Destination path.
+        timeout: Per-request timeout in seconds.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=dest.parent, delete=False, suffix=".tmp") as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        with requests.get(url, stream=True, timeout=timeout) as r:
+            r.raise_for_status()
+            with open(tmp_path, "wb") as fh:
+                for chunk in r.iter_content(chunk_size=1 << 20):
+                    if chunk:
+                        fh.write(chunk)
+        tmp_path.replace(dest)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def fetch_url(

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -63,15 +63,19 @@ class TestCacheDir:
         assert cache_dir() == override
         assert override.is_dir()
 
-    def test_fallback_when_unset(self, monkeypatch) -> None:
+    def test_fallback_when_unset(self, tmp_path: Path, monkeypatch) -> None:
+        fallback = tmp_path / "bdf-fallback"
         monkeypatch.delenv("BDF_CACHE_DIR", raising=False)
-        monkeypatch.setattr(fetch, "user_cache_dir", lambda subdir: "/tmp/bdf-fallback-xyz")
-        assert cache_dir("bdf") == Path("/tmp/bdf-fallback-xyz")
+        monkeypatch.setattr(fetch, "user_cache_dir", lambda subdir: str(fallback))
+        assert cache_dir("bdf") == fallback
+        assert fallback.is_dir()
 
-    def test_fallback_when_empty(self, monkeypatch) -> None:
+    def test_fallback_when_empty(self, tmp_path: Path, monkeypatch) -> None:
+        fallback = tmp_path / "bdf-fallback"
         monkeypatch.setenv("BDF_CACHE_DIR", "")
-        monkeypatch.setattr(fetch, "user_cache_dir", lambda subdir: "/tmp/bdf-fallback-xyz")
-        assert cache_dir("bdf") == Path("/tmp/bdf-fallback-xyz")
+        monkeypatch.setattr(fetch, "user_cache_dir", lambda subdir: str(fallback))
+        assert cache_dir("bdf") == fallback
+        assert fallback.is_dir()
 
     def test_cache_reuse_no_redownload(self, tmp_path: Path, monkeypatch) -> None:
         monkeypatch.setenv("BDF_CACHE_DIR", str(tmp_path))


### PR DESCRIPTION
## Summary

`bdf.fetch` downloaded a file into the system temporary directory, then renamed
it onto the cache path. A rename is atomic only inside one filesystem, so every
environment that splits `/tmp` from the cache directory raised
`OSError: [Errno 18] Invalid cross-device link` on any cache miss. The download
now writes its temporary file beside the destination, which restores the atomic
rename and makes the cache work under a tmpfs `/tmp`, a separate `/home`
partition, an NFS home directory, or a container bind mount.

## Fixes

- `_download` creates its temporary file in the destination directory instead of
  the system temporary directory, so the rename onto the cache path stays inside
  one filesystem and never raises `EXDEV`. This matches the pattern already used
  in `spec.py`, `file_utils.py`, and `scripts/update_battinfo.py`
  ([447572a](https://github.com/tomjholland/battery-data-format/commit/447572ad50284c1e0edd587c88749423205c7f9a))
- A failed download removes its temporary file rather than leaving a `.tmp`
  remnant in the cache directory, which matters because `fetch_url` retries each
  URL and falls through to `alt_urls`
  ([447572a](https://github.com/tomjholland/battery-data-format/commit/447572ad50284c1e0edd587c88749423205c7f9a))
- A large download no longer passes through the system temporary directory, so a
  RAM-backed tmpfs `/tmp` cannot fail the fetch with `ENOSPC`
  ([447572a](https://github.com/tomjholland/battery-data-format/commit/447572ad50284c1e0edd587c88749423205c7f9a))

## Tests

- `TestCacheDir::test_fallback_when_unset` and `test_fallback_when_empty` used a
  hard-coded `/tmp/bdf-fallback-xyz` path and failed wherever `/tmp` is not
  writable. Both use the `tmp_path` fixture now, and both assert that
  `cache_dir` creates the directory
  ([8213009](https://github.com/tomjholland/battery-data-format/commit/82130094954eef32946924666644f619f0d68f69))

## Verification

`uv run pytest -m "not network"` gives 853 passed, 19 skipped, 17 deselected.
The deselected cases fetch from Zenodo and need network access.
