### PR TITLE
Issue form for 0.2.0rc feedback, fix .github gitignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/rc-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/rc-feedback.yml
@@ -1,0 +1,26 @@
+name: 0.2.0 release candidate feedback
+description: Something surprising while testing a 0.2.0 release candidate
+labels: ["0.2.0rc"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `bdf --version`
+      placeholder: bdf 0.2.0rc2 (ontology snapshot 1.3.0)
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you ran, what you expected, what you got. Tracebacks and small data snippets welcome.
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Data source
+      description: Cycler/vendor and file type, if relevant (e.g. Neware .ndax, BioLogic .mpr)
+    validations:
+      required: false

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ openspec
 .worktrees
 .github/*
 !.github/workflows
+!.github/CODEOWNERS
+!.github/ISSUE_TEMPLATE/


### PR DESCRIPTION
Adds an issue form that auto-applies the new 0.2.0rc label so rc feedback is identifiable in triage (outside reporters cannot label issues; a form with labels frontmatter is the mechanism that can). Found and fixed along the way: the blanket .github/* gitignore was silently excluding CODEOWNERS and ISSUE_TEMPLATE from commits, which had quietly dropped CODEOWNERS out of #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)